### PR TITLE
Update GrailsGradlePlugin

### DIFF
--- a/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -455,7 +455,9 @@ class GrailsGradlePlugin extends GroovyPlugin {
                 agent
             }
             final String micronautVersion = project.properties['micronautVersion']
-            project.dependencies.add("runtimeOnly", "io.micronaut:micronaut-inject-groovy:${micronautVersion?:defaultMicronautVersion}")
+            if (project.configurations.findByName("developmentOnly")) {
+                project.dependencies.add("developmentOnly", "io.micronaut:micronaut-inject-groovy:${micronautVersion?:defaultMicronautVersion}")
+            }
             project.afterEvaluate(new AgentTasksEnhancer())
         }
     }


### PR DESCRIPTION
to add micronaut-inject-groovy with developmentOnly scope instead of runtimeOnly.

Fixes grails/gorm-hibernate5#253 and grails/grails-core#11816
