### PR TITLE
Update Grails GSP plugin

### DIFF
--- a/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPageForkCompileTask.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPageForkCompileTask.groovy
@@ -5,6 +5,7 @@ import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import org.codehaus.groovy.tools.shell.util.PackageHelper
 import org.gradle.api.Action
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Nested
@@ -14,6 +15,10 @@ import org.gradle.api.tasks.compile.AbstractCompile
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs
 import org.gradle.process.ExecResult
 import org.gradle.process.JavaExecSpec
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
 
 /**
  * Abstract Gradle task for compiling templates, using GroovyPageCompilerForkTask
@@ -33,6 +38,14 @@ class GroovyPageForkCompileTask extends AbstractCompile {
     @InputDirectory
     File srcDir
 
+    @Input
+    String tmpDirPath
+
+    /**
+     * @deprecated Use {@link #tmpDirPath} instead.
+     */
+    @Deprecated
+    @Optional
     @InputDirectory
     File tmpDir
 
@@ -92,10 +105,17 @@ class GroovyPageForkCompileTask extends AbstractCompile {
                             project.file("grails-app/conf/application.groovy").canonicalPath
                         ].join(',')
 
+                        Path path = Paths.get(tmpDirPath)
+                        File tmp = tmpDir
+                        if (Files.exists(path)) {
+                            tmp = path.toFile()
+                        } else {
+                            tmp = Files.createDirectories(path).toFile()
+                        }
                         def arguments = [
                             srcDir.canonicalPath,
                             destinationDir.canonicalPath,
-                            tmpDir.canonicalPath,
+                            tmp.canonicalPath,
                             targetCompatibility,
                             packageName,
                             serverpath,

--- a/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPagePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPagePlugin.groovy
@@ -6,6 +6,8 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.FileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetOutput
 import org.gradle.api.tasks.TaskContainer
@@ -51,9 +53,10 @@ class GroovyPagePlugin implements Plugin<Project> {
         }
 
         def allTasks = project.tasks
+
         def compileGroovyPages = allTasks.create("compileGroovyPages", GroovyPageForkCompileTask) {
             destinationDir = destDir
-            tmpDir = getTmpDir(project)
+            tmpDirPath = getTmpDirPath(project)
             source = project.file("${project.projectDir}/grails-app/views")
             serverpath = "/WEB-INF/grails-app/views/"
         }
@@ -63,7 +66,7 @@ class GroovyPagePlugin implements Plugin<Project> {
         def compileWebappGroovyPages = allTasks.create("compileWebappGroovyPages", GroovyPageForkCompileTask) {
             destinationDir = destDir
             source = project.file("${project.projectDir}/src/main/webapp")
-            tmpDir = getTmpDir(project)
+            tmpDirPath = getTmpDirPath(project)
             serverpath = "/"
         }
 
@@ -109,10 +112,9 @@ class GroovyPagePlugin implements Plugin<Project> {
         output?.classesDirs ?: project.files(new File(project.buildDir, "classes/main"))
     }
 
-    protected File getTmpDir(Project project) {
+    protected String getTmpDirPath(Project project) {
         def tmpdir = new File(project.buildDir as String, "gsptmp")
-        tmpdir.mkdirs()
-        return tmpdir
+        return tmpdir.absolutePath
     }
 
 }


### PR DESCRIPTION
* Fixes grails/grails-core#12123
* Deprecated input tmpDir of GroovyPageForkCompileTask as it is causing problems with Gradle 7 where it cannot be a non-existing directory and when combined with clean it maybe deleted when run on multi-core system.
* Instead use tmpDirPath, which will check and create directory at later point while executing the task