### PR TITLE
Upgrade grails and spring boot version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 projectVersion=5.0.1-SNAPSHOT
-grailsVersion=5.0.0
-springBootVersion=2.5.5
+grailsVersion=5.0.1
+springBootVersion=2.5.6
 groovyVersion=3.0.7


### PR DESCRIPTION
When use Grails 5.0.1 with grails-grade-plugin 5.0.0, build war contains spring boot 2.5.5, not 2.5.6