### PR TITLE
Use Java Gradle Plugin to automate Gradle Plugin Marker Artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ ext.pomInfo = {
 }
 
 apply plugin: 'idea'
-apply plugin: 'java-library'
+apply plugin: 'java-gradle-plugin'
 apply plugin: 'groovy'
 apply plugin: 'com.bmuschko.nexus'
 apply plugin: 'maven-publish'
@@ -106,6 +106,43 @@ dependencies {
     api "org.springframework.boot:spring-boot-gradle-plugin:$springBootVersion"
     api "io.spring.gradle:dependency-management-plugin:1.0.11.RELEASE"
     api "com.netflix.nebula:gradle-extra-configurations-plugin:7.0.0"
+}
+
+gradlePlugin {
+    plugins {
+        grailsCore {
+            id = 'org.grails.grails-core'
+            implementationClass = 'org.grails.gradle.plugin.core.GrailsGradlePlugin'
+        }
+        grailsDoc {
+            id = 'org.grails.grails-doc'
+            implementationClass = 'org.grails.gradle.plugin.doc.GrailsDocGradlePlugin'
+        }
+        grailsGsp {
+            id = 'org.grails.grails-gsp'
+            implementationClass = 'org.grails.gradle.plugin.web.gsp.GroovyPagePlugin'
+        }
+        grailsPlugin {
+            id = 'org.grails.grails-plugin'
+            implementationClass = 'org.grails.gradle.plugin.core.GrailsPluginGradlePlugin'
+        }
+        grailsProfile {
+            id = 'org.grails.grails-profile'
+            implementationClass = 'org.grails.gradle.plugin.profiles.GrailsProfileGradlePlugin'
+        }
+        grailsWeb {
+            id = 'org.grails.grails-web'
+            implementationClass = 'org.grails.gradle.plugin.web.GrailsWebGradlePlugin'
+        }
+        grailsPluginPublish {
+            id = 'org.grails.internal.grails-plugin-publish'
+            implementationClass = 'org.grails.gradle.plugin.publishing.internal.GrailsCentralPublishGradlePlugin'
+        }
+        grailsProfilePublish {
+            id = 'org.grails.internal.grails-profile-publish'
+            implementationClass = 'org.grails.gradle.plugin.profiles.internal.GrailsProfilePublishGradlePlugin'
+        }
+    }
 }
 
 jar {

--- a/src/main/groovy/org/grails/gradle/plugin/doc/PublishGuideTask.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/doc/PublishGuideTask.groovy
@@ -41,14 +41,15 @@ class PublishGuideTask extends AbstractCompile {
     @Optional
     File propertiesFile
 
-//    @InputDirectory
+    @InputDirectory
     @Optional
     File groovydocDir
 
-//    @InputDirectory
+    @InputDirectory
     @Optional
     File javadocDir
 
+    @InputDirectory
     File srcDir
 
     @Override

--- a/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPagePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPagePlugin.groovy
@@ -91,7 +91,11 @@ class GroovyPagePlugin implements Plugin<Project> {
 
         allTasks.withType(War) { War war ->
             war.dependsOn compileGroovyPages
-            war.classpath = war.classpath + project.files(destDir)
+            if (war.classpath) {
+                war.classpath = war.classpath + project.files(destDir)
+            } else {
+                war.classpath = project.files(destDir)
+            }
         }
         allTasks.withType(Jar) { Jar jar ->
             if(!(jar instanceof War)) {


### PR DESCRIPTION
The `plugins {}` DSL block only allows for declaring plugins by their globally unique plugin id and version properties, Gradle needs a way to look up the coordinates of the plugin implementation artifact. To do so, Gradle will look for a Plugin Marker Artifact with the coordinates plugin.id:plugin.id.gradle.plugin:plugin.version. This marker needs to have a dependency on the actual plugin implementation.

This PR will allow use of Grails Gradle Plugin from plugins block, for example: 
```
plugins {
    id "groovy" 
    id "org.grails.grails-web" 
    id "org.grails.grails-gsp" 
    ...
}
```

Please read more information about Plugin Markers at the [Official Gradle Documentation](https://docs.gradle.org/current/userguide/plugins.html#sec:plugin_markers)