### PR TITLE
Exclude logback.xml for plugin jar

### DIFF
--- a/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
@@ -190,6 +190,7 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
         jarTask.exclude "application.yml"
         jarTask.exclude "application.groovy"
         jarTask.exclude "logback.groovy"
+        jarTask.exclude "logback.xml"
     }
 
     @CompileDynamic


### PR DESCRIPTION
Since [Grails 5.1.2](https://github.com/grails/grails-core/releases/tag/v5.1.2) using logback.xml instead of logback.groovy, grails plugin should update this too.