### PR TITLE
Exclude scaffolding templates when package app

### DIFF
--- a/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -531,10 +531,6 @@ class GrailsGradlePlugin extends GroovyPlugin {
                         'info.app.grailsVersion': grailsVersion
                 ]
 
-                task.from(project.relativePath("src/main/templates")) {
-                    into("META-INF/templates")
-                }
-
                 if (!native2ascii) {
                     task.from(sourceSet.resources) {
                         include '**/*.properties'


### PR DESCRIPTION
If install scaffold templates, when package app war the templates also include `build/resources/main/META-INF/templates`. These templates should not be included.