### PR TITLE
Support set springBootVersion in Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,7 @@ dependencies {
         exclude group: "org.codehaus.gant", module: "gant_groovy1.8"
     }
 
+    compileOnly "org.apache.maven:maven-model:3.8.4"
     api "org.springframework.boot:spring-boot-gradle-plugin:$springBootVersion"
     api "io.spring.gradle:dependency-management-plugin:1.0.11.RELEASE"
     api "com.netflix.nebula:gradle-extra-configurations-plugin:7.0.0"

--- a/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -184,8 +184,12 @@ class GrailsGradlePlugin extends GroovyPlugin {
 
     @CompileDynamic
     private void applyBomImport(DependencyManagementExtension dme, project) {
+        String springBootVersion = project.findProperty('springBootVersion')
         dme.imports({
             mavenBom("org.grails:grails-bom:${project.properties['grailsVersion']}")
+            if (springBootVersion) {
+                mavenBom("org.springframework.boot:spring-boot-starter-parent:${springBootVersion}")
+            }
         })
         dme.setApplyMavenExclusions(false)
     }
@@ -249,6 +253,16 @@ class GrailsGradlePlugin extends GroovyPlugin {
                 } as Action<DependencyResolveDetails>)
             } as Action<Configuration>)
         }
+        project.configurations.all({ Configuration configuration ->
+            configuration.resolutionStrategy.eachDependency({ DependencyResolveDetails details ->
+                String dependencyName = details.requested.name
+                String group = details.requested.group
+                if (group == 'jakarta.annotation' && dependencyName == 'jakarta.annotation-api') {
+                    details.useVersion('2.0.0')
+                    return
+                }
+            } as Action<DependencyResolveDetails>)
+        } as Action<Configuration>)
     }
 
     @CompileStatic

--- a/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -58,6 +58,7 @@ import org.grails.gradle.plugin.model.GrailsClasspathToolingModelBuilder
 import org.grails.gradle.plugin.run.FindMainClassTask
 import org.grails.gradle.plugin.util.SourceSets
 import org.grails.io.support.FactoriesLoaderSupport
+import org.springframework.boot.cli.compiler.dependencies.SpringBootDependenciesDependencyManagement
 import org.springframework.boot.gradle.dsl.SpringBootExtension
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 import org.springframework.boot.gradle.tasks.bundling.BootArchive
@@ -184,12 +185,10 @@ class GrailsGradlePlugin extends GroovyPlugin {
 
     @CompileDynamic
     private void applyBomImport(DependencyManagementExtension dme, project) {
-        String springBootVersion = project.findProperty('springBootVersion')
+        String springBootVersion = resolveSpringBootVersion(project)
         dme.imports({
             mavenBom("org.grails:grails-bom:${project.properties['grailsVersion']}")
-            if (springBootVersion) {
-                mavenBom("org.springframework.boot:spring-boot-starter-parent:${springBootVersion}")
-            }
+            mavenBom("org.springframework.boot:spring-boot-starter-parent:${springBootVersion}")
         })
         dme.setApplyMavenExclusions(false)
     }
@@ -392,6 +391,16 @@ class GrailsGradlePlugin extends GroovyPlugin {
             grailsVersion = grailsCoreDep.version
         }
         grailsVersion
+    }
+
+    protected String resolveSpringBootVersion(Project project) {
+        def springBootVersion = project.findProperty('springBootVersion')
+
+        if (!springBootVersion) {
+            springBootVersion = new SpringBootDependenciesDependencyManagement().getSpringBootVersion()
+        }
+
+        springBootVersion
     }
 
     @CompileDynamic


### PR DESCRIPTION
Fixed issue #104:

Update in `gradle.properties` will apply new version of Spring Boot

Use managed dependency versions that are provided by Spring Boot

`spring-framework.version`=5.3.19
`mysql.version`=8.0.28