### PR TITLE
Improving cachability of GroovyPageForkCompileTask

### DIFF
--- a/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPageForkCompileTask.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPageForkCompileTask.groovy
@@ -1,15 +1,17 @@
 package org.grails.gradle.plugin.web.gsp
 
-import grails.io.ResourceUtils
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
-import org.codehaus.groovy.tools.shell.util.PackageHelper
 import org.gradle.api.Action
-import org.gradle.api.provider.Property
+import org.gradle.api.file.FileTree
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.LocalState
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.compile.AbstractCompile
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs
@@ -35,10 +37,10 @@ class GroovyPageForkCompileTask extends AbstractCompile {
     @Optional
     String packageName
 
-    @InputDirectory
+    @Internal
     File srcDir
 
-    @Input
+    @LocalState
     String tmpDirPath
 
     /**
@@ -55,6 +57,12 @@ class GroovyPageForkCompileTask extends AbstractCompile {
 
     @Nested
     GspCompileOptions compileOptions = new GspCompileOptions()
+
+    @Override
+    @PathSensitive(PathSensitivity.RELATIVE)
+    FileTree getSource() {
+        return super.getSource()
+    }
 
     @Override
     void setSource(Object source) {


### PR DESCRIPTION
During analysis of the open source project Rundeck, it was discovered that GroovyPageForkCompile tasks were not cacheable when no changes were made, but the absolute path was different between projects.  This will improve the cacheability of these outputs particularly when using a remote cache.

See Pull Request for Rundeck changes:  https://github.com/rundeck/rundeck/pull/7865

