### PR TITLE
Access propertyGetter instead of name

### DIFF
--- a/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -319,7 +319,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
                     project.tasks.create(taskName, ApplicationContextCommandTask) {
                         classpath = fileCollection
                         command = commandName
-                        systemProperty Environment.KEY, System.getProperty(Environment.KEY, Environment.DEVELOPMENT.name)
+                        systemProperty Environment.KEY, System.getProperty(Environment.KEY, Environment.DEVELOPMENT.getName())
                         if (project.hasProperty('args')) {
                             args(CommandLineParser.translateCommandline(project.args))
                         }


### PR DESCRIPTION
In previous Grails 5.1, the Environment class is a Java class so it throws `java.lang.AbstractMethodError`.

This fixes grails/grails-core#12733 by calling `getName()` on Environment.