### PR TITLE
Fix version unspecified after update to Grails 6

### DIFF
--- a/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -60,7 +60,6 @@ import org.grails.gradle.plugin.util.SourceSets
 import org.grails.io.support.FactoriesLoaderSupport
 import org.springframework.boot.gradle.dsl.SpringBootExtension
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
-import org.springframework.boot.gradle.tasks.bundling.BootArchive
 
 import javax.inject.Inject
 

--- a/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -135,7 +135,9 @@ class GrailsGradlePlugin extends GroovyPlugin {
 
         configureApplicationCommands(project)
 
-        createBuildPropertiesTask(project)
+        project.gradle.projectsEvaluated {
+            createBuildPropertiesTask(project)
+        }
 
         configureRunScript(project)
 
@@ -227,10 +229,8 @@ class GrailsGradlePlugin extends GroovyPlugin {
                 }
             }
 
-            project.afterEvaluate {
-                TaskContainer tasks = project.tasks
-                tasks.findByName("processResources")?.dependsOn(buildPropertiesTask)
-            }
+            TaskContainer tasks = project.tasks
+            tasks.findByName("processResources")?.dependsOn(buildPropertiesTask)
         }
     }
 

--- a/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
@@ -63,7 +63,9 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
 
         configureAstSources(project)
 
-        configureProjectNameAndVersionASTMetadata(project)
+        project.gradle.projectsEvaluated {
+            configureProjectNameAndVersionASTMetadata(project)
+        }
 
         configurePluginResources(project)
 


### PR DESCRIPTION
After update to Grails 6, setting the `version = x.y.z` in `build.gradle` no longer had effect. Setting it in `gradle.properties` did however. 

The problem seems to be that the `version` is (and must be) declared after the `plugins {}` section in build.gradle. This means that the version value is not available when the plugin code is run.

This pull request makes the code retrieving the version run after the project is evaluated, and fixes this issue.