### PR TITLE
Allow preventing of global slf4j-simple exclusion. Fixes #222

### DIFF
--- a/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -146,9 +146,16 @@ class GrailsGradlePlugin extends GroovyPlugin {
     }
 
     protected void excludeDependencies(Project project) {
-        project.configurations.all ({ Configuration configuration ->
-            configuration.exclude group:"org.slf4j", module: "slf4j-simple"
-        })
+        // Perhaps change to check that if this is a Grails plugin, don't exclude?
+        // Adding an exclusion to every dependency in a pom is very verbose and
+        // greatly increases the size of the pom. 
+        // It would be nice to have documented in a comment why this global exclude is in here
+        String slf4jPreventExclusion = project.properties['slf4jPreventExclusion']
+        if (!slf4jPreventExclusion || slf4jPreventExclusion != 'true') {
+            project.configurations.all ({ Configuration configuration ->
+                configuration.exclude group:"org.slf4j", module: "slf4j-simple"
+            })
+        }
     }
 
     protected void configureProfile(Project project) {


### PR DESCRIPTION
Default behavior keeps thing as is, but introduces a setting 

```properties
slf4jPreventExclusion=true
```

that can be added to `gradle.properties` to prevent the global exclusion 