### PR TITLE
Add source set dependencies back to `integrationTestImplementation`

### DIFF
--- a/src/main/groovy/org/grails/gradle/plugin/core/IntegrationTestGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/core/IntegrationTestGradlePlugin.groovy
@@ -20,6 +20,7 @@ import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.SourceSetOutput
@@ -61,6 +62,9 @@ class IntegrationTestGradlePlugin implements Plugin<Project> {
             final File resources = new File(project.projectDir, "grails-app/conf")
             integrationTest.resources.srcDir(resources)
 
+            final DependencyHandler dependencies = project.dependencies
+            dependencies.add("integrationTestImplementation", mainSourceSetOutput)
+            dependencies.add("integrationTestImplementation", testSourceSetOutput)
             project.configurations.named("integrationTestImplementation") {
                 it.extendsFrom(project.configurations.named("testImplementation").get())
             }


### PR DESCRIPTION
After some investigation, I found out that the problem is not that "plugins can overwrite message bundles" in integration tests, but that version 6 of the plugin mistakenly removed main/test source set dependencies from configuration `integrationTestImplementation`.

I added back the _file dependencies_ so that it behaves like version 5. This solves #235

Please note that _configuration dependencies_ are the only ones that are deprecated and should be replaced by `Configuration#extendsFrom`.
