### PR TITLE
Fix Gradle deprecations

### DIFF
--- a/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
@@ -120,7 +120,7 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
         def taskContainer = project.tasks
         if(taskContainer.findByName('sourcesJar') == null) {
             def jarTask = taskContainer.create("sourcesJar", Jar)
-            jarTask.classifier = 'sources'
+            jarTask.archiveClassifier = 'sources'
             jarTask.from SourceSets.findMainSourceSet(project).allSource
         }
     }
@@ -174,7 +174,7 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
         if (groovydocTask) {
             if( taskContainer.findByName('javadocJar') == null) {
                 taskContainer.create("javadocJar", Jar).configure {
-                    classifier = 'javadoc'
+                    archiveClassifier = 'javadoc'
                     from groovydocTask.outputs
                 }.dependsOn(javadocTask)
             }

--- a/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfileGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfileGradlePlugin.groovy
@@ -150,8 +150,8 @@ class GrailsProfileGradlePlugin implements Plugin<Project> {
             jar.from(skeletonsDir) { CopySpec spec ->
                 spec.into("skeleton")
             }
-            jar.classifier = "sources"
-            jar.destinationDir = new File(project.buildDir, "libs")
+            jar.archiveClassifier = "sources"
+            jar.destinationDirectory = new File(project.buildDir, "libs")
             jar.setDescription("Assembles a jar archive containing the profile sources.")
             jar.setGroup(BUILD_GROUP)
 

--- a/src/main/groovy/org/grails/gradle/plugin/profiles/internal/GrailsProfilePublishGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/profiles/internal/GrailsProfilePublishGradlePlugin.groovy
@@ -48,7 +48,7 @@ class GrailsProfilePublishGradlePlugin extends GrailsCentralPublishGradlePlugin 
         tempReadmeForJavadoc << "https://central.sonatype.org/publish/requirements/#supply-javadoc-and-sources"
         project.tasks.create("javadocJar", Jar, (Action) { Jar jar ->
             jar.from(tempReadmeForJavadoc)
-            jar.classifier = "javadoc"
+            jar.archiveClassifier = "javadoc"
             jar.destinationDir = new File(project.buildDir, "libs")
             jar.setDescription("Assembles a jar archive containing the profile javadoc.")
             jar.setGroup(BUILD_GROUP)


### PR DESCRIPTION
These no longer work on the latest Gradle version:
https://docs.gradle.org/current/userguide/upgrading_version_7.html#abstractarchivetask_api_cleanup
