### PR TITLE
fix(build): Cleanup dependency management

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,12 +73,16 @@ java {
 }
 
 configurations.configureEach {
+    // This is a workaround for grails-shell exposing a different version of Groovy
+    // than the one used by Gradle. This causes issues with the Groovy compiler.
     resolutionStrategy.force "org.codehaus.groovy:groovy-xml:$GroovySystem.version"
 }
 
 dependencies {
     implementation "io.github.gradle-nexus:publish-plugin:1.3.0"
     implementation "com.bmuschko:gradle-nexus-plugin:2.3.1"
+    implementation "org.grails:grails-bootstrap:$grailsVersion"
+    implementation "org.grails:grails-gradle-model:$grailsVersion"
     implementation "org.grails:grails-shell:$grailsVersion"
     implementation "org.springframework.boot:spring-boot-gradle-plugin:$springBootVersion"
     implementation "io.spring.gradle:dependency-management-plugin:1.1.4"

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,9 @@
 buildscript {
     repositories {
-        maven { url "https://repo.grails.org/grails/core" }
-        maven { url "https://plugins.gradle.org/m2/" }
+        gradlePluginPortal()
     }
     dependencies {
         classpath "io.github.gradle-nexus:publish-plugin:1.3.0"
-        classpath "com.bmuschko:gradle-nexus-plugin:2.3.1"
     }
 }
 
@@ -69,51 +67,21 @@ if (isReleaseVersion) {
 sourceCompatibility = "1.11"
 targetCompatibility = "1.11"
 
-configurations {
-    documentation
-}
-
 java {
     withJavadocJar()
     withSourcesJar()
 }
 
-configurations {
-    all {
-        resolutionStrategy.force 'org.codehaus.groovy:groovy-xml:3.0.13'
-    }
+configurations.configureEach {
+    resolutionStrategy.force "org.codehaus.groovy:groovy-xml:$GroovySystem.version"
 }
 
 dependencies {
-    documentation "org.fusesource.jansi:jansi:2.4.1"
-    documentation "org.codehaus.groovy:groovy-cli-picocli:$groovyVersion"
-
-    api gradleApi()
-    api "io.github.gradle-nexus:publish-plugin:1.3.0"
-    api "com.bmuschko:gradle-nexus-plugin:2.3.1"
-    api "org.grails:grails-gradle-model:$grailsVersion"
-    api "org.grails:grails-shell:$grailsVersion", {
-        exclude group: "org.slf4j", module: "slf4j-simple"
-    }
-    api "org.grails:grails-bootstrap:$grailsVersion", {
-        exclude group: "org.fusesource.jansi", module: "jansi"
-        exclude group: "jline", module: "jline"
-        exclude group: "net.java.dev.jna", module: "jna"
-
-        // Ant
-        exclude group: "org.codehaus.groovy", module: "groovy-ant"
-        exclude group: "org.apache.ant", module: "ant"
-        exclude group: "org.apache.ant", module: "ant-launcher"
-        exclude group: "org.apache.ivy", module: "ivy"
-        exclude group: "org.apache.ant", module: "ant-trax"
-        exclude group: "org.apache.ant", module: "ant-junit"
-
-        exclude group: "org.codehaus.gant", module: "gant_groovy1.8"
-    }
-
-    api "org.springframework.boot:spring-boot-gradle-plugin:$springBootVersion"
-    api "io.spring.gradle:dependency-management-plugin:1.1.4"
-    api "com.netflix.nebula:gradle-extra-configurations-plugin:7.0.0"
+    implementation "io.github.gradle-nexus:publish-plugin:1.3.0"
+    implementation "com.bmuschko:gradle-nexus-plugin:2.3.1"
+    implementation "org.grails:grails-shell:$grailsVersion"
+    implementation "org.springframework.boot:spring-boot-gradle-plugin:$springBootVersion"
+    implementation "io.spring.gradle:dependency-management-plugin:1.1.4"
 }
 
 gradlePlugin {
@@ -191,7 +159,6 @@ configure([compileJava, compileTestJava]) {
 
 configure([groovydoc]) {
     destinationDir = project.file("build/docs/api")
-    classpath += configurations.documentation
 }
 
 configure([javadoc]) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,6 @@
 projectVersion=6.1.2-SNAPSHOT
 grailsVersion=6.1.1
 springBootVersion=2.7.18
-groovyVersion=3.0.11
 
 org.gradle.caching=true
 org.gradle.daemon=true


### PR DESCRIPTION
All dependencies were declared with the api scope which is not necessary and which leaks dependencies to downstream projects. After this change it should no longer be necessary for Grails apps to force the version of groovy-xml. Several unused dependencies have also been removed.