### PR TITLE
ci: Fix Github workflows for Grails 7

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['11', '14', '17']
+        java: ['17']
     env:
       WORKSPACE: ${{ github.workspace }}
     steps:
@@ -20,7 +20,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: temurin
           java-version: ${{ matrix.java }}
       - name: Run Build
         id: build
@@ -38,8 +38,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
-          java-version: '11'
+          distribution: temurin
+          java-version: 17
       - name: Publish Artifacts (repo.grails.org)
         id: publish
         uses: gradle/gradle-build-action@v3
@@ -68,8 +68,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
-          java-version: '11'
+          distribution: temurin
+          java-version: 17
       - name: Generate Groovydoc
         id: groovydoc
         uses: gradle/gradle-build-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
-          java-version: '11'
+          distribution: temurin
+          java-version: 17
       - name: Extract Target Branch
         id: extract_branch
         run: |
@@ -83,8 +83,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
-          java-version: '11'
+          distribution: temurin
+          java-version: 17
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -125,8 +125,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
-          java-version: '11'
+          distribution: temurin
+          java-version: 17
       - name: Generate Groovydoc
         id: groovydoc
         uses: gradle/gradle-build-action@v3


### PR DESCRIPTION
The CI workflows were building with Java 11, 14 and 17, but Grails 7 is now built with Java 17 so we can no longer build with 11 and 14.