### PR TITLE
Revert "Make Gradle 8.9 compatable"

### DIFF
--- a/src/main/groovy/org/grails/gradle/plugin/web/gsp/GspCompileOptions.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/web/gsp/GspCompileOptions.groovy
@@ -1,30 +1,22 @@
 package org.grails.gradle.plugin.web.gsp
 
-import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
-import org.gradle.api.tasks.compile.AbstractOptions
 import org.gradle.api.tasks.compile.BaseForkOptions
 import org.gradle.api.tasks.compile.GroovyForkOptions
-import javax.inject.Inject;
 
 /**
- * Presents the Compile Options used by the {@llink GroovyPageForkCompileTask}
- *
- * @author David Estes
- * @since 4.0
- */
-class GspCompileOptions extends AbstractOptions {
+* Presents the Compile Options used by the {@llink GroovyPageForkCompileTask}
+*
+* @author David Estes
+* @since 4.0
+*/
+class GspCompileOptions implements Serializable {
     private static final long serialVersionUID = 0L;
 
     @Input
-    String encoding = "UTF-8"
-
-    @Inject
-    protected ObjectFactory getObjectFactory() {
-        throw new UnsupportedOperationException();
-    }
+	String encoding = "UTF-8"
 
     @Nested
-    GroovyForkOptions forkOptions = getObjectFactory().newInstance(GroovyForkOptions.class)
+    GroovyForkOptions forkOptions = new GroovyForkOptions()
 }


### PR DESCRIPTION
Reverts grails/grails-gradle-plugin#311

clearly broken.