### PR TITLE
Use groovy 3 for compilation of gradle plugin. Ensure specified version of groovy 4 on app.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ java {
 }
 
 // resolve conflict from Gradle's version of Groovy. Not needed if Gradle switches to 4.0
-configurations.configureEach { exclude group: 'org.apache.groovy', module: 'groovy-xml' }
+configurations.configureEach { exclude group: 'org.apache.groovy' }
 
 dependencies {
     implementation "io.github.gradle-nexus:publish-plugin:2.0.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,6 @@ projectVersion=7.0.0-SNAPSHOT
 grailsVersion=7.0.0-SNAPSHOT
 grailsShellVersion=7.0.0-SNAPSHOT
 springBootVersion=3.3.3
-groovyVersion=4.0.22
 org.gradle.caching=true
 org.gradle.daemon=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx1536M -XX:MaxMetaspaceSize=512M

--- a/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -265,9 +265,15 @@ class GrailsGradlePlugin extends GroovyPlugin {
                 configuration.resolutionStrategy.eachDependency({ DependencyResolveDetails details ->
                     String dependencyName = details.requested.name
                     String group = details.requested.group
-                    if (group == 'org.codehaus.groovy' && dependencyName.startsWith('groovy')) {
+                    if (group == 'org.codehaus.groovy') {
+                        if (dependencyName == 'groovy-all') {
+                            details.useTarget "org.apache.groovy:groovy:$groovyVersion"
+                        } else {
+                            details.useTarget "org.apache.groovy:$dependencyName:$groovyVersion"
+                        }
+                        details.because('groovy version substituted for groovy 4')
+                    } else if (group == 'org.apache.groovy' && dependencyName.startsWith('groovy')) {
                         details.useVersion(groovyVersion)
-                        return
                     }
                 } as Action<DependencyResolveDetails>)
             } as Action<Configuration>)


### PR DESCRIPTION
Handles cases where versions of Groovy prior to 4 will not be resolved into the app.