### PR TITLE
Set duplicates strategy for all archive tasks

### DIFF
--- a/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -44,6 +44,7 @@ import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetOutput
 import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.bundling.AbstractArchiveTask
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.compile.GroovyCompile
 import org.gradle.api.tasks.testing.Test
@@ -143,6 +144,8 @@ class GrailsGradlePlugin extends GroovyPlugin {
         configureRunCommand(project)
 
         configurePathingJar(project)
+
+        configureArchiveCommands(project)
     }
 
     protected void excludeDependencies(Project project) {
@@ -701,5 +704,12 @@ class GrailsGradlePlugin extends GroovyPlugin {
             fileCollection = fileCollection + it.filter({ File file-> !file.name.startsWith("spring-boot-devtools")})
         }
         fileCollection
+    }
+
+    protected void configureArchiveCommands(Project project) {
+        project.tasks.withType(AbstractArchiveTask).configureEach {
+            // the zip format supports duplicates and gradle implements this feature, so exclude them
+            it.duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+        }
     }
 }


### PR DESCRIPTION
Currently a Grails 7 application will require specifying the duplicatesStrategy for the following tasks.

This should be defined at a higher level in `GrailsGradlePlugin`, so it is not necessary to set it in each Grails project/application.  

The Zip format supports duplicates, gradle implements this zip feature and puts duplicates into the archives, so EXCLUDE is a better option. 

```
bootJar {
    duplicatesStrategy = duplicatesStrategy.EXCLUDE
}

distTar {
    duplicatesStrategy = duplicatesStrategy.EXCLUDE
}

distZip {
    duplicatesStrategy = duplicatesStrategy.EXCLUDE
}

```
Examples

https://github.com/grails/grails-async/blob/7.0.x/examples/pubsub-demo/build.gradle#L55-L65

https://github.com/grails/grails-views/blob/577d1c5bea1d88d446dbc7d48f950bfe3160fb0e/examples/functional-tests/build.gradle#L60-L66


