### PR TITLE
#350 - Rework publishing plugins so they can be used externally and on multi-project builds

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['17']
+        java: ['17', '21']
     env:
       WORKSPACE: ${{ github.workspace }}
     steps:
@@ -67,8 +67,8 @@ jobs:
     permissions:
       contents: write
     env:
-      GIT_USER_NAME: 'grails-build'
-      GIT_USER_EMAIL: 'grails-build@users.noreply.github.com'
+      GIT_USER_NAME: grails-build
+      GIT_USER_EMAIL: grails-build@users.noreply.github.com
     steps:
       - name: "📥 Checkout repository"
         uses: actions/checkout@v4
@@ -81,15 +81,13 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
         with:
           develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-      - name: Generate Groovydoc
+      - name: "📜 Generate Groovydoc"
         id: groovydoc
-        uses: gradle/gradle-build-action@v3
         env:
           DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
           DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-        with:
-          arguments: groovydoc
-      - name: Publish to Github Pages
+        run: ./gradle groovydoc
+      - name: "🚀 Publish to Github Pages"
         id: docs
         if: success()
         uses: grails/github-pages-deploy-action@v2
@@ -100,6 +98,5 @@ jobs:
           BRANCH: gh-pages
           FOLDER: build/docs
           DOC_FOLDER: gh-pages
-          COMMIT_EMAIL: behlp@unityfoundation.io
-          COMMIT_NAME: Puneet Behl
-          VERSION: ${{ needs.publish.outputs.release_version }}
+          COMMIT_EMAIL: ${{ env.GIT_USER_EMAIL }}
+          COMMIT_NAME: ${{ env.GIT_USER_NAME }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -67,8 +67,8 @@ jobs:
     permissions:
       contents: write
     env:
-      GIT_USER_NAME: puneetbehl
-      GIT_USER_EMAIL: behlp@unityfoundation.io
+      GIT_USER_NAME: 'grails-build'
+      GIT_USER_EMAIL: 'grails-build@users.noreply.github.com'
     steps:
       - name: "📥 Checkout repository"
         uses: actions/checkout@v4

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,8 +13,6 @@ jobs:
     strategy:
       matrix:
         java: ['17', '21']
-    env:
-      WORKSPACE: ${{ github.workspace }}
     steps:
       - name: "📥 Checkout repository"
         uses: actions/checkout@v4
@@ -86,7 +84,7 @@ jobs:
         env:
           DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
           DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-        run: ./gradle groovydoc
+        run: ./gradlew groovydoc
       - name: "🚀 Publish to Github Pages"
         id: docs
         if: success()

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,41 +16,50 @@ jobs:
     env:
       WORKSPACE: ${{ github.workspace }}
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK
+      - name: "📥 Checkout repository"
+        uses: actions/checkout@v4
+      - name: "☕️ Setup JDK"
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: liberica
           java-version: ${{ matrix.java }}
-      - name: Run Build
-        id: build
-        uses: gradle/gradle-build-action@v3
-        env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      - name: "🐘 Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
         with:
-          arguments: build -Dgeb.env=chromeHeadless
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      - name: "🔨 Build project"
+        id: build
+        env:
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+        run: ./gradlew build
   publish:
     if: github.event_name == 'push'
     needs: ['build']
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK
+      - name: "📥 Checkout repository"
+        uses: actions/checkout@v4
+      - name: "☕️ Setup JDK"
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: liberica
           java-version: 17
-      - name: Publish Artifacts (repo.grails.org)
+      - name: "🐘 Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      - name: "📤 Publish Snapshot Artifacts to Artifactory (repo.grails.org/libs-snapshot-local)"
         id: publish
-        uses: gradle/gradle-build-action@v3
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-        with:
-          arguments: | 
-            -Dorg.gradle.internal.publish.checksums.insecure=true 
-            publish
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+        run: >
+          ./gradlew
+          -Dorg.gradle.internal.publish.checksums.insecure=true
+          publish
   docs:
     if: github.event_name == 'push'
     needs: publish
@@ -61,18 +70,23 @@ jobs:
       GIT_USER_NAME: puneetbehl
       GIT_USER_EMAIL: behlp@unityfoundation.io
     steps:
-      - name: Checkout repository
+      - name: "📥 Checkout repository"
         uses: actions/checkout@v4
-      - name: Set up JDK
+      - name: "☕️ Setup JDK"
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: liberica
           java-version: 17
+      - name: "🐘 Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       - name: Generate Groovydoc
         id: groovydoc
         uses: gradle/gradle-build-action@v3
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
         with:
           arguments: groovydoc
       - name: Publish to Github Pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,40 +12,43 @@ jobs:
       release_version: ${{ steps.release_version.outputs.value }}
       target_branch: ${{ steps.extract_branch.outputs.value }}
     env:
-      GIT_USER_NAME: puneetbehl
-      GIT_USER_EMAIL: behlp@unityfoundation.io
+      GIT_USER_NAME: 'grails-build'
+      GIT_USER_EMAIL: 'grails-build@users.noreply.github.com'
     steps:
-      - name: Checkout repository
+      - name: "📥 Checkout repository"
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_TOKEN }}
-      - name: Set up JDK
+      - name: "☕️ Setup JDK"
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: liberica
           java-version: 17
-      - name: Extract Target Branch
+      - name: "🐘 Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      - name: "📝 Store the target branch"
         id: extract_branch
         run: |
           echo "Determining Target Branch"
-          TARGET_BRANCH=`cat $GITHUB_EVENT_PATH | jq '.release.target_commitish' | sed -e 's/^"\(.*\)"$/\1/g'`
+          TARGET_BRANCH=${GITHUB_REF#refs/heads/}
           echo $TARGET_BRANCH
           echo "value=${TARGET_BRANCH}" >> $GITHUB_OUTPUT
-      - name: Set the current release version
+      - name: "📝 Store the current release version"
         id: release_version
         run: echo "value=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
-      - name: Run pre-release
+      - name: "⚙️ Run pre-release"
         uses: micronaut-projects/github-actions/pre-release@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run Assemble
+      - name: "🧩 Run Assemble"
         if: success()
         id: assemble
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: assemble
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+        run: ./gradlew assemble
       - name: Upload Distribution
         if: success()
         uses: actions/upload-artifact@v4
@@ -67,7 +70,8 @@ jobs:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
           SECRING_FILE: ${{ secrets.SECRING_FILE }}
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
         with:
           arguments: |
             -Psigning.secretKeyRingFile=${{ github.workspace }}/secring.gpg 
@@ -93,7 +97,8 @@ jobs:
       - name: Nexus Staging Close And Release
         uses: gradle/gradle-build-action@v3
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
@@ -114,8 +119,8 @@ jobs:
     permissions:
       contents: write
     env:
-      GIT_USER_NAME: puneetbehl
-      GIT_USER_EMAIL: behlp@unityfoundation.io
+      GIT_USER_NAME: 'grails-build'
+      GIT_USER_EMAIL: 'grails-build@users.noreply.github.com'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -131,7 +136,8 @@ jobs:
         id: groovydoc
         uses: gradle/gradle-build-action@v3
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
         with:
           arguments: groovydoc
       - name: Publish to Github Pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,19 +49,18 @@ jobs:
           DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
           DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
         run: ./gradlew assemble
-      - name: Upload Distribution
+      - name: "🚀 Upload Distribution"
         if: success()
         uses: actions/upload-artifact@v4
         with:
           name: grails-${{ steps.release_version.outputs.value }}.zip
           path: build/distributions/grails-${{ steps.release_version.outputs.value }}.zip
-      - name: Generate secring file
+      - name: "📝 Generate secring file"
         env:
           SECRING_FILE: ${{ secrets.SECRING_FILE }}
         run: echo $SECRING_FILE | base64 -d > ${{ github.workspace }}/secring.gpg
-      - name: Publish to Sonatype OSSRH
+      - name: "🚀 Publish to Sonatype OSSRH"
         id: publish
-        uses: gradle/gradle-build-action@v3
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -72,8 +71,8 @@ jobs:
           SECRING_FILE: ${{ secrets.SECRING_FILE }}
           DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
           DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-        with:
-          arguments: |
+        run: |
+            ./gradlew
             -Psigning.secretKeyRingFile=${{ github.workspace }}/secring.gpg 
             publishToSonatype 
             closeSonatypeStagingRepository
@@ -83,27 +82,31 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK
+      - name: "📥 Checkout repository"
+        uses: actions/checkout@v4
+      - name: "☕️ Setup JDK"
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: liberica
           java-version: 17
-      - name: Checkout repository
+      - name: "📥 Checkout repository"
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_TOKEN }}
           ref: v${{ needs.publish.outputs.release_version }}
+      - name: "🐘 Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       - name: Nexus Staging Close And Release
-        uses: gradle/gradle-build-action@v3
         env:
           DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
           DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
-        with:
-          arguments: |
+        run: |
+            ./gradlew
             findSonatypeStagingRepository
             releaseSonatypeStagingRepository
       - name: Run post-release
@@ -122,36 +125,34 @@ jobs:
       GIT_USER_NAME: 'grails-build'
       GIT_USER_EMAIL: 'grails-build@users.noreply.github.com'
     steps:
-      - name: Checkout repository
+      - name: "📥 Checkout repository"
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_TOKEN }}
           ref: v${{ needs.publish.outputs.release_version }}
-      - name: Set up JDK
+      - name: "☕️ Setup JDK"
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: liberica
           java-version: 17
-      - name: Generate Groovydoc
+      - name: "📜 Generate Groovydoc"
         id: groovydoc
-        uses: gradle/gradle-build-action@v3
         env:
           DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
           DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-        with:
-          arguments: groovydoc
-      - name: Publish to Github Pages
+        run: ./gradlew groovydoc
+      - name: "🚀 Publish to Github Pages"
         id: docs
         if: success()
         uses: grails/github-pages-deploy-action@v2
         env:
           SKIP_SNAPSHOT: ${{ contains(needs.publish.outputs.release_version, 'M') }}
-          SKIP_LATEST: ${{ !startsWith(needs.publish.outputs.target_branch, '6.1') }}
+          SKIP_LATEST: ${{ !startsWith(needs.publish.outputs.target_branch, '6.2') }}
           TARGET_REPOSITORY: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           BRANCH: gh-pages
           FOLDER: build/docs
           DOC_FOLDER: gh-pages
           COMMIT_EMAIL: ${{ env.GIT_USER_EMAIL }}
-          COMMIT_NAME: Puneet Behl
+          COMMIT_NAME: ${{ env.GIT_USER_NAME }}
           VERSION: ${{ needs.publish.outputs.release_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           SECRING_FILE: ${{ secrets.SECRING_FILE }}
           DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
           DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-        run: |
+        run: >
             ./gradlew
             -Psigning.secretKeyRingFile=${{ github.workspace }}/secring.gpg 
             publishToSonatype 
@@ -105,7 +105,7 @@ jobs:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
-        run: |
+        run: >
             ./gradlew
             findSonatypeStagingRepository
             releaseSonatypeStagingRepository
@@ -135,6 +135,10 @@ jobs:
         with:
           distribution: liberica
           java-version: 17
+      - name: "🐘 Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       - name: "📜 Generate Groovydoc"
         id: groovydoc
         env:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ _Todo_: Add the docs
 
 grails-publish
 ---------
-A Gradle plugin to simplify publishing to either an Artifactory or Maven Central endpoint for snapshots & to Maven Central for releases.  
+A Gradle plugin to simplify publishing:
+
+1. snapshots with either the Maven Publish gradle plugin or Nexus Publish gradle plugin.
+2. releases with the Nexus Publish gradle plugin.
 
 Example Usage:
 
@@ -52,11 +55,11 @@ Example Usage:
         license {
             name = 'Apache-2.0'
         }
-        issueTrackerUrl = 'http://github.com/myname/myplugin/issues'
-        vcsUrl = 'http://github.com/myname/myplugin'
-        title = "My plugin title"
-        desc = "My plugin description"
-        developers = [johndoe:"John Doe"]
+        issueTrackerUrl = 'https://github.com/myname/myplugin/issues'
+        vcsUrl = 'https://github.com/myname/myplugin'
+        title = 'My plugin title'
+        desc = 'My plugin description'
+        developers = [johndoe: 'John Doe']
     }
 
 or
@@ -66,22 +69,22 @@ or
         license {
             name = 'Apache-2.0'
         }
-        title = "My plugin title"
-        desc = "My plugin description"
-        developers = [johndoe:"John Doe"]
+        title = 'My plugin title'
+        desc = 'My plugin description'
+        developers = [johndoe: 'John Doe']
     }
 
-By default this plugin will publish to the specified Artifactory instance for snapshots, and Maven Central for releases.  To change the snapshot publish behavior, you can set the `snapshotRepoType` to `RepositoryType.CENTRAL`.
+By default this plugin will publish to the specified `MAVEN_PUBLISH` instance for snapshots, and `NEXUS_PUBLISH` for releases.  To change the snapshot publish behavior, you can set the `snapshotRepoType` to `RepositoryTarget.NEXUS_PUBLISH`.
 
 The credentials and connection url must be specified as a project property or an environment variable.
 
-Artifactory Environment Variables are:
+The `MAVEN_PUBLISH` Environment Variables are:
 
     ARTIFACTORY_USERNAME
     ARTIFACTORY_PASSWORD
     ARTIFACTORY_URL
 
-Sonatype Environment Variables are:
+The `NEXUS_PUBLISH` Environment Variables are:
 
     SONATYPE_NEXUS_URL
     SONATYPE_SNAPSHOT_URL

--- a/README.md
+++ b/README.md
@@ -25,10 +25,6 @@ grails-gsp
 ---------
 * Configure GSP Compiling Task
 
-grails-plugin-publish
----------
-_Todo_: Add the docs
-
 grails-plugin
 ---------
 * Configure Ast Sources
@@ -40,6 +36,58 @@ grails-plugin
 grails-profile
 ---------
 _Todo_: Add the docs
+
+grails-profile-publish
+---------
+_Todo_: Add the docs
+
+grails-publish
+---------
+A Gradle plugin to simplify publishing to either an Artifactory or Maven Central endpoint for snapshots & to Maven Central for releases.  
+
+Example Usage:
+
+    grailsPublish {
+        websiteUrl = 'http://foo.com/myplugin'
+        license {
+            name = 'Apache-2.0'
+        }
+        issueTrackerUrl = 'http://github.com/myname/myplugin/issues'
+        vcsUrl = 'http://github.com/myname/myplugin'
+        title = "My plugin title"
+        desc = "My plugin description"
+        developers = [johndoe:"John Doe"]
+    }
+
+or
+
+    grailsPublish {
+        githubSlug = 'foo/bar'
+        license {
+            name = 'Apache-2.0'
+        }
+        title = "My plugin title"
+        desc = "My plugin description"
+        developers = [johndoe:"John Doe"]
+    }
+
+By default this plugin will publish to the specified Artifactory instance for snapshots, and Maven Central for releases.  To change the snapshot publish behavior, you can set the `snapshotRepoType` to `RepositoryType.CENTRAL`.
+
+The credentials and connection url must be specified as a project property or an environment variable.
+
+Artifactory Environment Variables are:
+
+    ARTIFACTORY_USERNAME
+    ARTIFACTORY_PASSWORD
+    ARTIFACTORY_URL
+
+Sonatype Environment Variables are:
+
+    SONATYPE_NEXUS_URL
+    SONATYPE_SNAPSHOT_URL
+    SONATYPE_USERNAME
+    SONATYPE_PASSWORD
+    SONATYPE_STAGING_PROFILE_ID
 
 grails-web
 ---------

--- a/README.md
+++ b/README.md
@@ -43,10 +43,7 @@ _Todo_: Add the docs
 
 grails-publish
 ---------
-A Gradle plugin to simplify publishing:
-
-1. snapshots with either the Maven Publish gradle plugin or Nexus Publish gradle plugin.
-2. releases with the Nexus Publish gradle plugin.
+A Gradle plugin to ease publishing with the maven publish plugin or the nexus publish plugin.
 
 Example Usage:
 
@@ -74,23 +71,23 @@ or
         developers = [johndoe: 'John Doe']
     }
 
-By default this plugin will publish to the specified `MAVEN_PUBLISH` instance for snapshots, and `NEXUS_PUBLISH` for releases.  To change the snapshot publish behavior, you can set the `snapshotRepoType` to `RepositoryTarget.NEXUS_PUBLISH`.
+By default this plugin will publish to the specified `MAVEN_PUBLISH` instance for snapshots, and `NEXUS_PUBLISH` for releases.  To change the snapshot publish behavior, set `snapshotRepoType` to `PublishType.NEXUS_PUBLISH`. To change the release publish behavior,  set `releaseRepoType` to `PublishType.NEXUS_PUBLISH`.
 
 The credentials and connection url must be specified as a project property or an environment variable.
 
-The `MAVEN_PUBLISH` Environment Variables are:
+`MAVEN_PUBLISH` Environment Variables are:
 
-    ARTIFACTORY_USERNAME
-    ARTIFACTORY_PASSWORD
-    ARTIFACTORY_URL
+    MAVEN_PUBLISH_USERNAME
+    MAVEN_PUBLISH_PASSWORD
+    MAVEN_PUBLISH_URL
 
-The `NEXUS_PUBLISH` Environment Variables are:
+`NEXUS_PUBLISH` Environment Variables are:
 
-    SONATYPE_NEXUS_URL
-    SONATYPE_SNAPSHOT_URL
-    SONATYPE_USERNAME
-    SONATYPE_PASSWORD
-    SONATYPE_STAGING_PROFILE_ID
+    NEXUS_PUBLISH_URL
+    NEXUS_PUBLISH_SNAPSHOT_URL
+    NEXUS_PUBLISH_USERNAME
+    NEXUS_PUBLISH_PASSWORD
+    NEXUS_PUBLISH_STAGING_PROFILE_ID
 
 grails-web
 ---------

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ or
         developers = [johndoe: 'John Doe']
     }
 
-By default this plugin will publish to the specified `MAVEN_PUBLISH` instance for snapshots, and `NEXUS_PUBLISH` for releases.  To change the snapshot publish behavior, set `snapshotRepoType` to `PublishType.NEXUS_PUBLISH`. To change the release publish behavior,  set `releaseRepoType` to `PublishType.NEXUS_PUBLISH`.
+By default, this plugin will publish to the specified `MAVEN_PUBLISH` instance for snapshots, and `NEXUS_PUBLISH` for releases.  To change the snapshot publish behavior, set `snapshotRepoType` to `PublishType.NEXUS_PUBLISH`. To change the release publish behavior, set `releaseRepoType` to `PublishType.MAVEN_PUBLISH`.
 
 The credentials and connection url must be specified as a project property or an environment variable.
 
@@ -83,10 +83,10 @@ The credentials and connection url must be specified as a project property or an
 
 `NEXUS_PUBLISH` Environment Variables are:
 
-    NEXUS_PUBLISH_URL
-    NEXUS_PUBLISH_SNAPSHOT_URL
     NEXUS_PUBLISH_USERNAME
     NEXUS_PUBLISH_PASSWORD
+    NEXUS_PUBLISH_URL
+    NEXUS_PUBLISH_SNAPSHOT_URL
     NEXUS_PUBLISH_STAGING_PROFILE_ID
 
 grails-web

--- a/build.gradle
+++ b/build.gradle
@@ -138,15 +138,15 @@ gradlePlugin {
         }
         grailsPluginPublish {
             displayName = "Grails Publish Gradle Plugin"
-            description = 'A plugin to setup publishing to Grails central repo'
-            id = 'org.grails.internal.grails-plugin-publish'
-            implementationClass = 'org.grails.gradle.plugin.publishing.internal.GrailsCentralPublishGradlePlugin'
+            description = 'A plugin to assist in publishing Grails related artifacts'
+            id = 'org.grails.grails-plugin-publish'
+            implementationClass = 'org.grails.gradle.plugin.publishing.GrailsCentralPublishGradlePlugin'
         }
         grailsProfilePublish {
             displayName = "Grails Profile Publish Plugin"
             description = 'A plugin for publishing profiles'
-            id = 'org.grails.internal.grails-profile-publish'
-            implementationClass = 'org.grails.gradle.plugin.profiles.internal.GrailsProfilePublishGradlePlugin'
+            id = 'org.grails.grails-profile-publish'
+            implementationClass = 'org.grails.gradle.plugin.profiles.GrailsProfilePublishGradlePlugin'
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,7 +8,7 @@ def isLocal = !isCI
 def isAuthenticated = System.getenv('DEVELOCITY_ACCESS_KEY') != null
 def isBuildCacheAuthenticated =
 		System.getenv('DEVELOCITY_BUILD_CACHE_NODE_USER') != null &&
-				System.getenv('DEVELOCITY_BUILD_CACHE_NODE_KEY') != null
+		System.getenv('DEVELOCITY_BUILD_CACHE_NODE_KEY') != null
 
 develocity {
 	server = 'https://ge.grails.org'

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,4 +31,4 @@ buildCache {
 }
 
 
-rootProject.name = "grails-gradle-plugin"
+rootProject.name = 'grails-gradle-plugin'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,27 +1,34 @@
 plugins {
-//    id "com.gradle.enterprise" version "3.17.2"
-//    id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.1'
+	id 'com.gradle.develocity' version '3.18.1'
+	id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.2'
 }
 
-//gradleEnterprise {
-//    server = 'https://ge.grails.org'
-//    buildScan {
-//        publishAlwaysIf(System.getenv('CI') == 'true')
-//        publishIfAuthenticated()
-//        uploadInBackground = System.getenv("CI") == null
-//        capture {
-//            taskInputFiles = true
-//        }
-//    }
-//}
+def isCI = System.getenv('CI') != null
+def isLocal = !isCI
+def isAuthenticated = System.getenv('DEVELOCITY_ACCESS_KEY') != null
+def isBuildCacheAuthenticated =
+		System.getenv('DEVELOCITY_BUILD_CACHE_NODE_USER') != null &&
+				System.getenv('DEVELOCITY_BUILD_CACHE_NODE_KEY') != null
 
-//buildCache {
-//    local { enabled = System.getenv('CI') != 'true' }
-//    remote(gradleEnterprise.buildCache) {
-//        def isAuthenticated = System.getenv('GRADLE_ENTERPRISE_ACCESS_KEY')
-//        push = System.getenv('CI') == 'true' && isAuthenticated
-//        enabled = true
-//    }}
+develocity {
+	server = 'https://ge.grails.org'
+	buildScan {
+		publishing.onlyIf { isAuthenticated }
+		uploadInBackground = isLocal
+	}
+}
+
+buildCache {
+	local { enabled = isLocal }
+	remote(develocity.buildCache) {
+		push = isCI && isBuildCacheAuthenticated
+		enabled = true
+		usernameAndPassword(
+				System.getenv('DEVELOCITY_BUILD_CACHE_NODE_USER') ?: '',
+				System.getenv('DEVELOCITY_BUILD_CACHE_NODE_KEY') ?: ''
+		)
+	}
+}
 
 
 rootProject.name = "grails-gradle-plugin"

--- a/src/main/groovy/org/grails/gradle/plugin/agent/AgentTasksEnhancer.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/agent/AgentTasksEnhancer.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.grails.gradle.plugin.agent
 
 import groovy.transform.CompileStatic

--- a/src/main/groovy/org/grails/gradle/plugin/commands/ApplicationContextCommandTask.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/commands/ApplicationContextCommandTask.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 original authors
+ * Copyright 2014-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/org/grails/gradle/plugin/commands/ApplicationContextScriptTask.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/commands/ApplicationContextScriptTask.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.grails.gradle.plugin.commands
 
 import groovy.transform.CompileStatic

--- a/src/main/groovy/org/grails/gradle/plugin/core/GrailsExtension.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/core/GrailsExtension.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.grails.gradle.plugin.core
 
 import groovy.transform.CompileStatic

--- a/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/org/grails/gradle/plugin/core/IntegrationTestGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/core/IntegrationTestGradlePlugin.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/org/grails/gradle/plugin/core/PluginDefiner.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/core/PluginDefiner.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.grails.gradle.plugin.core
 
 import grails.util.BuildSettings

--- a/src/main/groovy/org/grails/gradle/plugin/doc/GrailsDocGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/doc/GrailsDocGradlePlugin.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 original authors
+ * Copyright 2014-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/org/grails/gradle/plugin/doc/PublishGuideTask.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/doc/PublishGuideTask.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 original authors
+ * Copyright 2014-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/org/grails/gradle/plugin/model/GrailsClasspathToolingModelBuilder.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/model/GrailsClasspathToolingModelBuilder.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.grails.gradle.plugin.model
 
 import groovy.transform.CompileStatic

--- a/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfileGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfileGradlePlugin.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfilePublishGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfilePublishGradlePlugin.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.XmlProvider
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.DependencySet
 import org.gradle.api.artifacts.SelfResolvingDependency
+import org.gradle.api.publish.maven.MavenPom
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.bundling.Jar
 import org.grails.gradle.plugin.publishing.GrailsPublishGradlePlugin
@@ -43,13 +44,13 @@ class GrailsProfilePublishGradlePlugin extends GrailsPublishGradlePlugin {
     @Override
     void apply(Project project) {
         super.apply(project)
-        final File tempReadmeForJavadoc = Files.createTempFile("README", "txt").toFile()
-        tempReadmeForJavadoc << "https://central.sonatype.org/publish/requirements/#supply-javadoc-and-sources"
-        project.tasks.create("javadocJar", Jar, { Jar jar ->
+        final File tempReadmeForJavadoc = Files.createTempFile('README', 'txt').toFile()
+        tempReadmeForJavadoc << 'https://central.sonatype.org/publish/requirements/#supply-javadoc-and-sources'
+        project.tasks.create('javadocJar', Jar, { Jar jar ->
             jar.from(tempReadmeForJavadoc)
-            jar.archiveClassifier.set("javadoc")
-            jar.destinationDirectory.set(new File(project.layout.buildDirectory.getAsFile().get(), "libs"))
-            jar.setDescription("Assembles a jar archive containing the profile javadoc.")
+            jar.archiveClassifier.set('javadoc')
+            jar.destinationDirectory.set(new File(project.layout.buildDirectory.getAsFile().get(), 'libs'))
+            jar.setDescription('Assembles a jar archive containing the profile javadoc.')
             jar.setGroup(BUILD_GROUP)
         })
     }
@@ -68,10 +69,10 @@ class GrailsProfilePublishGradlePlugin extends GrailsPublishGradlePlugin {
 
     @Override
     protected void doAddArtefact(Project project, MavenPublication publication) {
-        publication.artifact(project.tasks.findByName("jar"))
-        publication.pom(new Action<org.gradle.api.publish.maven.MavenPom>() {
+        publication.artifact(project.tasks.findByName('jar'))
+        publication.pom(new Action<MavenPom>() {
             @Override
-            void execute(org.gradle.api.publish.maven.MavenPom mavenPom) {
+            void execute(MavenPom mavenPom) {
                 mavenPom.withXml(new Action<XmlProvider>() {
                     @Override
                     void execute(XmlProvider xml) {

--- a/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfilePublishGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfilePublishGradlePlugin.groovy
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.grails.gradle.plugin.profiles.internal
+package org.grails.gradle.plugin.profiles
 
 
 import groovy.transform.CompileStatic
@@ -25,8 +25,7 @@ import org.gradle.api.artifacts.DependencySet
 import org.gradle.api.artifacts.SelfResolvingDependency
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.bundling.Jar
-import org.grails.gradle.plugin.profiles.GrailsProfileGradlePlugin
-import org.grails.gradle.plugin.publishing.internal.GrailsCentralPublishGradlePlugin
+import org.grails.gradle.plugin.publishing.GrailsPublishGradlePlugin
 
 import java.nio.file.Files
 
@@ -39,7 +38,7 @@ import static org.gradle.api.plugins.BasePlugin.BUILD_GROUP
  * @since 3.1
  */
 @CompileStatic
-class GrailsProfilePublishGradlePlugin extends GrailsCentralPublishGradlePlugin {
+class GrailsProfilePublishGradlePlugin extends GrailsPublishGradlePlugin {
 
     @Override
     void apply(Project project) {
@@ -56,16 +55,6 @@ class GrailsProfilePublishGradlePlugin extends GrailsCentralPublishGradlePlugin 
     }
 
     @Override
-    protected String getDefaultGrailsCentralReleaseRepo() {
-        "https://repo.grails.org/grails/libs-releases-local"
-    }
-
-    @Override
-    protected String getDefaultGrailsCentralSnapshotRepo() {
-        "https://repo.grails.org/grails/libs-snapshots-local"
-    }
-
-    @Override
     protected Map<String, String> getDefaultExtraArtifact(Project project) {
         [source: "${project.buildDir}/classes/profile/META-INF/grails-profile/profile.yml".toString(),
          classifier: defaultClassifier,
@@ -75,11 +64,6 @@ class GrailsProfilePublishGradlePlugin extends GrailsCentralPublishGradlePlugin 
     @Override
     protected String getDefaultClassifier() {
         'profile'
-    }
-
-    @Override
-    protected String getDefaultRepo() {
-        'profiles'
     }
 
     @Override

--- a/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfilePublishGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfilePublishGradlePlugin.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 package org.grails.gradle.plugin.profiles
-
 
 import groovy.transform.CompileStatic
 import org.gradle.api.Action

--- a/src/main/groovy/org/grails/gradle/plugin/profiles/tasks/ProfileCompilerTask.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/profiles/tasks/ProfileCompilerTask.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.grails.gradle.plugin.profiles.tasks
 
 import groovy.transform.CompileStatic

--- a/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishExtension.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishExtension.groovy
@@ -28,7 +28,7 @@ class GrailsPublishExtension {
     /**
      * Determines the snapshot repository to publish to
      */
-    RepositoryType snapshotRepoType = RepositoryType.ARTIFACTORY
+    RepositoryTarget snapshotRepoType = RepositoryTarget.MAVEN_PUBLISH
 
     /**
      * The slug from github

--- a/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishExtension.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishExtension.groovy
@@ -21,14 +21,20 @@ import org.gradle.util.ConfigureUtil
 
 /**
  * @author Puneet Behl
+ * @author James Daugherty
  * @since 4.0.11
  */
 @CompileStatic
 class GrailsPublishExtension {
     /**
-     * Determines the snapshot repository to publish to
+     * Determines which plugin is used to publish snapshots
      */
-    RepositoryTarget snapshotRepoType = RepositoryTarget.MAVEN_PUBLISH
+    PublishType snapshotPublishType = PublishType.MAVEN_PUBLISH
+
+    /**
+     * Determines which plugin is used to publish releases
+     */
+    PublishType releasePublishType = PublishType.NEXUS_PUBLISH
 
     /**
      * The slug from github

--- a/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishExtension.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishExtension.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.grails.gradle.plugin.publishing.internal
+package org.grails.gradle.plugin.publishing
 
 import groovy.transform.CompileStatic
 import org.gradle.util.ConfigureUtil
@@ -25,6 +25,10 @@ import org.gradle.util.ConfigureUtil
  */
 @CompileStatic
 class GrailsPublishExtension {
+    /**
+     * Determines the snapshot repository to publish to
+     */
+    RepositoryType snapshotRepoType = RepositoryType.ARTIFACTORY
 
     /**
      * The slug from github
@@ -32,22 +36,12 @@ class GrailsPublishExtension {
     String githubSlug
 
     /**
-     * The the publishing user
-     */
-    String user
-
-    /**
-     * The the publishing key
-     */
-    String key
-
-    /**
-     * The website URL of the plugin
+     * The website URL of the published project
      */
     String websiteUrl
 
     /**
-     * The source control URL of the plugin
+     * The source control URL of the project
      */
     String vcsUrl
 
@@ -57,12 +51,12 @@ class GrailsPublishExtension {
     License license = new License()
 
     /**
-     * The developers of the plugin
+     * The developers of the project
      */
     Map<String, String> developers = [:]
 
     /**
-     * Title of the plugin, defaults to the project name
+     * Title of the project, defaults to the project name
      */
     String title
 
@@ -72,46 +66,9 @@ class GrailsPublishExtension {
     String desc
 
     /**
-     * THe organisation on bintray
-     */
-    String userOrg
-
-    /**
-     * THe repository on bintray
-     */
-    String repo
-
-    /**
      * The issue tracker URL
      */
     String issueTrackerUrl
-
-    /**
-     * Whether to GPG sign
-     */
-    boolean gpgSign = false
-
-    /**
-     * The passphrase to sign, only required if `gpgSign == true`
-     */
-    String signingPassphrase
-
-    /**
-     * Whether to sync to Maven central
-     */
-    boolean mavenCentralSync = false
-
-    /**
-     * Username for maven central
-     */
-    String sonatypeOssUsername
-
-    /**
-     * Password for maven central
-     */
-    String sonatypeOssPassword
-
-    String snapshotUrl
 
     License getLicense() {
         return license

--- a/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishExtension.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishExtension.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.grails.gradle.plugin.publishing
 
 import groovy.transform.CompileStatic

--- a/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishGradlePlugin.groovy
@@ -17,6 +17,7 @@
 package org.grails.gradle.plugin.publishing
 
 import grails.util.GrailsNameUtils
+import io.github.gradlenexus.publishplugin.InitializeNexusStagingRepository
 import io.github.gradlenexus.publishplugin.NexusPublishPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -51,11 +52,11 @@ grailsPublish {
     license {
         name = 'Apache-2.0'
     }
-    issueTrackerUrl = 'http://github.com/myname/myplugin/issues'
-    vcsUrl = 'http://github.com/myname/myplugin'
-    title = "My plugin title"
-    desc = "My plugin description"
-    developers = [johndoe:"John Doe"]
+    issueTrackerUrl = 'https://github.com/myname/myplugin/issues'
+    vcsUrl = 'https://github.com/myname/myplugin'
+    title = 'My plugin title'
+    desc = 'My plugin description'
+    developers = [johndoe: 'John Doe']
 }
 
 or
@@ -65,19 +66,19 @@ grailsPublish {
     license {
         name = 'Apache-2.0'
     }
-    title = "My plugin title"
-    desc = "My plugin description"
-    developers = [johndoe:"John Doe"]
+    title = 'My plugin title'
+    desc = 'My plugin description'
+    developers = [johndoe: 'John Doe']
 }
 
 The credentials and connection url must be specified as a project property or an environment variable:
 
-Artifactory Environment Variables are:
+`MAVEN_PUBLISH` Environment Variables are:
     ARTIFACTORY_USERNAME
     ARTIFACTORY_PASSWORD
     ARTIFACTORY_URL
 
-Sonatype Environment Variables are:
+`NEXUS_PUBLISH` Environment Variables are:
     SONATYPE_NEXUS_URL
     SONATYPE_SNAPSHOT_URL
     SONATYPE_USERNAME
@@ -91,33 +92,33 @@ Sonatype Environment Variables are:
     void apply(Project project) {
         final ExtensionContainer extensionContainer = project.extensions
         final TaskContainer taskContainer = project.tasks
-        final GrailsPublishExtension gpe = extensionContainer.create("grailsPublish", GrailsPublishExtension)
+        final GrailsPublishExtension gpe = extensionContainer.create('grailsPublish', GrailsPublishExtension)
 
-        final String artifactoryUsername = project.findProperty("artifactoryPublishUsername") ?: System.getenv("ARTIFACTORY_USERNAME") ?: ''
-        final String artifactoryPassword = project.findProperty("artifactoryPublishPassword") ?: System.getenv("ARTIFACTORY_PASSWORD") ?: ''
-        final String artifactoryPublishUrl = project.findProperty("artifactoryPublishUrl") ?: System.getenv("ARTIFACTORY_URL") ?: ''
-        final String sonatypeNexusUrl = project.findProperty("sonatypeNexusUrl") ?: System.getenv("SONATYPE_NEXUS_URL") ?: ''
-        final String sonatypeSnapshotUrl = project.findProperty("sonatypeSnapshotUrl") ?: System.getenv("SONATYPE_SNAPSHOT_URL") ?: ''
-        final String sonatypeUsername = project.findProperty("sonatypeUsername") ?: System.getenv("SONATYPE_USERNAME") ?: ''
-        final String sonatypePassword = project.findProperty("sonatypePassword") ?: System.getenv("SONATYPE_PASSWORD") ?: ''
-        final String sonatypeStagingProfileId = project.findProperty("sonatypeStagingProfileId") ?: System.getenv("SONATYPE_STAGING_PROFILE_ID") ?: ''
+        final String artifactoryUsername = project.findProperty('artifactoryPublishUsername') ?: System.getenv('ARTIFACTORY_USERNAME') ?: ''
+        final String artifactoryPassword = project.findProperty('artifactoryPublishPassword') ?: System.getenv('ARTIFACTORY_PASSWORD') ?: ''
+        final String artifactoryPublishUrl = project.findProperty('artifactoryPublishUrl') ?: System.getenv('ARTIFACTORY_URL') ?: ''
+        final String sonatypeNexusUrl = project.findProperty('sonatypeNexusUrl') ?: System.getenv('SONATYPE_NEXUS_URL') ?: ''
+        final String sonatypeSnapshotUrl = project.findProperty('sonatypeSnapshotUrl') ?: System.getenv('SONATYPE_SNAPSHOT_URL') ?: ''
+        final String sonatypeUsername = project.findProperty('sonatypeUsername') ?: System.getenv('SONATYPE_USERNAME') ?: ''
+        final String sonatypePassword = project.findProperty('sonatypePassword') ?: System.getenv('SONATYPE_PASSWORD') ?: ''
+        final String sonatypeStagingProfileId = project.findProperty('sonatypeStagingProfileId') ?: System.getenv('SONATYPE_STAGING_PROFILE_ID') ?: ''
 
         final ExtraPropertiesExtension extraPropertiesExtension = extensionContainer.findByType(ExtraPropertiesExtension)
 
-        extraPropertiesExtension.setProperty(SIGNING_KEY_ID, project.hasProperty(SIGNING_KEY_ID) ? project[SIGNING_KEY_ID] : System.getenv("SIGNING_KEY") ?: null)
-        extraPropertiesExtension.setProperty(SIGNING_PASSWORD, project.hasProperty(SIGNING_PASSWORD) ? project[SIGNING_PASSWORD] : System.getenv("SIGNING_PASSPHRASE") ?: null)
-        extraPropertiesExtension.setProperty(SIGNING_KEYRING, project.hasProperty(SIGNING_KEYRING) ? project[SIGNING_KEYRING] : System.getenv("SIGNING_KEYRING") ?: null)
+        extraPropertiesExtension.setProperty(SIGNING_KEY_ID, project.hasProperty(SIGNING_KEY_ID) ? project[SIGNING_KEY_ID] : System.getenv('SIGNING_KEY') ?: null)
+        extraPropertiesExtension.setProperty(SIGNING_PASSWORD, project.hasProperty(SIGNING_PASSWORD) ? project[SIGNING_PASSWORD] : System.getenv('SIGNING_PASSPHRASE') ?: null)
+        extraPropertiesExtension.setProperty(SIGNING_KEYRING, project.hasProperty(SIGNING_KEYRING) ? project[SIGNING_KEYRING] : System.getenv('SIGNING_KEYRING') ?: null)
 
         project.afterEvaluate {
-            RepositoryType snapshotType = gpe.snapshotRepoType
-            boolean isSnapshot = project.version.endsWith("SNAPSHOT")
+            RepositoryTarget snapshotType = gpe.snapshotRepoType
+            boolean isSnapshot = project.version.endsWith('SNAPSHOT')
             boolean isRelease = !isSnapshot
             final PluginManager projectPluginManager = project.getPluginManager()
             final PluginManager rootProjectPluginManager = project.rootProject.getPluginManager()
-            projectPluginManager.apply(MavenPublishPlugin.class)
+            projectPluginManager.apply(MavenPublishPlugin)
 
             project.publishing {
-                if (isSnapshot && snapshotType == RepositoryType.ARTIFACTORY) {
+                if (isSnapshot && snapshotType == RepositoryTarget.MAVEN_PUBLISH) {
                     System.setProperty('org.gradle.internal.publish.checksums.insecure', true as String)
                     repositories {
                         maven {
@@ -126,10 +127,10 @@ Sonatype Environment Variables are:
                                 password = artifactoryPassword
                             }
 
-                            if(!artifactoryPublishUrl) {
-                                throw new RuntimeException("Could not locate a project property of `artifactoryPublishUrl` or an environment variable of `ARTIFACTORY_URL` for the snapshot url")
+                            if (!artifactoryPublishUrl) {
+                                throw new RuntimeException('Could not locate a project property of `artifactoryPublishUrl` or an environment variable of `ARTIFACTORY_URL` for the snapshot url')
                             }
-                            url artifactoryPublishUrl
+                            url = artifactoryPublishUrl
                         }
                     }
                 }
@@ -139,11 +140,11 @@ Sonatype Environment Variables are:
                         artifactId project.name
 
                         doAddArtefact(project, delegate)
-                        def sourcesJar = taskContainer.findByName("sourcesJar")
+                        def sourcesJar = taskContainer.findByName('sourcesJar')
                         if (sourcesJar != null) {
                             artifact sourcesJar
                         }
-                        def javadocJar = taskContainer.findByName("javadocJar")
+                        def javadocJar = taskContainer.findByName('javadocJar')
                         if (javadocJar != null) {
                             artifact javadocJar
                         }
@@ -262,17 +263,17 @@ Sonatype Environment Variables are:
                 }
             }
 
-            if (isRelease || (isSnapshot && snapshotType == RepositoryType.CENTRAL)) {
-                rootProjectPluginManager.apply(NexusPublishPlugin.class)
-                projectPluginManager.apply(SigningPlugin.class)
+            if (isRelease || (isSnapshot && snapshotType == RepositoryTarget.NEXUS_PUBLISH)) {
+                rootProjectPluginManager.apply(NexusPublishPlugin)
+                projectPluginManager.apply(SigningPlugin)
 
                 extensionContainer.configure(SigningExtension, {
                     it.required = isRelease
                     it.sign project.publishing.publications.maven
                 })
 
-                project.rootProject.tasks.withType(io.github.gradlenexus.publishplugin.InitializeNexusStagingRepository).configureEach { io.github.gradlenexus.publishplugin.InitializeNexusStagingRepository task ->
-                    task.setShouldRunAfter(project.tasks.withType(Sign))
+                project.rootProject.tasks.withType(InitializeNexusStagingRepository).configureEach { InitializeNexusStagingRepository task ->
+                    task.shouldRunAfter = project.tasks.withType(Sign)
                 }
 
                 project.tasks.withType(Sign) {

--- a/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishGradlePlugin.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -126,7 +126,7 @@ The credentials and connection url must be specified as a project property or an
         // Required for the pom always
         projectPluginManager.apply(MavenPublishPlugin)
 
-        if(nexusPublish) {
+        if (nexusPublish) {
             rootProjectPluginManager.apply(NexusPublishPlugin)
             projectPluginManager.apply(SigningPlugin)
         }

--- a/src/main/groovy/org/grails/gradle/plugin/publishing/PublishType.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/publishing/PublishType.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.grails.gradle.plugin.publishing
 
 enum PublishType {

--- a/src/main/groovy/org/grails/gradle/plugin/publishing/PublishType.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/publishing/PublishType.groovy
@@ -1,6 +1,6 @@
 package org.grails.gradle.plugin.publishing
 
-enum RepositoryTarget {
+enum PublishType {
     MAVEN_PUBLISH,
     NEXUS_PUBLISH
 }

--- a/src/main/groovy/org/grails/gradle/plugin/publishing/RepositoryTarget.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/publishing/RepositoryTarget.groovy
@@ -1,0 +1,6 @@
+package org.grails.gradle.plugin.publishing
+
+enum RepositoryTarget {
+    MAVEN_PUBLISH,
+    NEXUS_PUBLISH
+}

--- a/src/main/groovy/org/grails/gradle/plugin/publishing/RepositoryType.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/publishing/RepositoryType.groovy
@@ -1,6 +1,0 @@
-package org.grails.gradle.plugin.publishing
-
-enum RepositoryType {
-    ARTIFACTORY, // standard maven repository such as artifactory
-    CENTRAL // maven central
-}

--- a/src/main/groovy/org/grails/gradle/plugin/publishing/RepositoryType.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/publishing/RepositoryType.groovy
@@ -1,0 +1,6 @@
+package org.grails.gradle.plugin.publishing
+
+enum RepositoryType {
+    ARTIFACTORY, // standard maven repository such as artifactory
+    CENTRAL // maven central
+}

--- a/src/main/groovy/org/grails/gradle/plugin/run/FindMainClassTask.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/run/FindMainClassTask.groovy
@@ -1,18 +1,30 @@
+/*
+ * Copyright 2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.grails.gradle.plugin.run
 
-import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.ExtraPropertiesExtension
-import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetOutput
 import org.gradle.api.tasks.TaskAction
 import org.grails.gradle.plugin.util.SourceSets
 import org.grails.io.support.MainClassFinder
-import org.springframework.boot.gradle.tasks.bundling.BootArchive
 import org.springframework.boot.gradle.tasks.run.BootRun
 
 /**

--- a/src/main/groovy/org/grails/gradle/plugin/run/GrailsRunTask.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/run/GrailsRunTask.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/org/grails/gradle/plugin/util/SourceSets.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/util/SourceSets.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.grails.gradle.plugin.util
 
 import groovy.transform.CompileStatic

--- a/src/main/groovy/org/grails/gradle/plugin/web/GrailsWebGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/web/GrailsWebGradlePlugin.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 original authors
+ * Copyright 2014-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPageForkCompileTask.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPageForkCompileTask.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.grails.gradle.plugin.web.gsp
 
 import groovy.transform.CompileDynamic

--- a/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPagePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPagePlugin.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.grails.gradle.plugin.web.gsp
 
 import groovy.transform.CompileDynamic

--- a/src/main/groovy/org/grails/gradle/plugin/web/gsp/GspCompileOptions.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/web/gsp/GspCompileOptions.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.grails.gradle.plugin.web.gsp
 
 import org.gradle.api.model.ObjectFactory
@@ -5,7 +20,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.compile.AbstractOptions
 import org.gradle.api.tasks.compile.GroovyForkOptions
-import javax.inject.Inject;
+import javax.inject.Inject
 
 /**
  * Presents the Compile Options used by the {@llink GroovyPageForkCompileTask}

--- a/src/main/resources/META-INF/gradle-plugins/org.grails.grails-profile-publish.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.grails.grails-profile-publish.properties
@@ -1,0 +1,1 @@
+implementation-class=org.grails.gradle.plugin.profiles.GrailsProfilePublishGradlePlugin

--- a/src/main/resources/META-INF/gradle-plugins/org.grails.grails-publish.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.grails.grails-publish.properties
@@ -1,0 +1,1 @@
+implementation-class=org.grails.gradle.plugin.publishing.GrailsPublishGradlePlugin

--- a/src/main/resources/META-INF/gradle-plugins/org.grails.internal.grails-plugin-publish.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.grails.internal.grails-plugin-publish.properties
@@ -1,1 +1,0 @@
-implementation-class=org.grails.gradle.plugin.publishing.internal.GrailsCentralPublishGradlePlugin

--- a/src/main/resources/META-INF/gradle-plugins/org.grails.internal.grails-profile-publish.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.grails.internal.grails-profile-publish.properties
@@ -1,1 +1,0 @@
-implementation-class=org.grails.gradle.plugin.profiles.internal.GrailsProfilePublishGradlePlugin


### PR DESCRIPTION
This change resolves #350.  At a high level it: 
1. Removes unused extension properties
2. Removes "internal" from publish namespaces & Rename plugins to reflect they aren't only for grails central
3. Updates the gradle enterprise logic that was commented out with the initial upgrade to grails 7 (jumps to latest version)
4. Updates the github actions to match grails-core (to pickup the gradle enterprise updates)
5. Adds documentation for the publish plugin
6. Supports publishing to artifactory or maven central for snapshots
7. Migrates the username, password, and url properties to properties / environment variables only.  using a publish plugin will require a snapshot url property to be defined based on the snapshot repository type.  My assumption is we'll add these to the gradle.properties in each project
8. Supports defining the `grailsPublish` block at the subproject level.

With these changes, any project can remove the gradle boiler plate of publishing to maven central & an artifactory snapshot instance.  Technically, it doesn't have to be a grails project to use this plugin.  If it is a grails plugin then the plugin.xml will be added as an artifact for the publish plugin and for the profile plugin it will generate the associated profile.xml.

I tested the snapshot portion of this logic with this code [spring security rest code](https://github.com/jdaugherty/grails-spring-security-rest/commit/ed5d25e99d53d6e22f13af22e25ac72ded130c0f).  @jeffscottbrown was kind enough to assist in testing.  You can find an example artifact [here](https://repo.grails.org/ui/native/plugins3-snapshots-local/org/grails/plugins/spring-security-rest-testapp-profile/6.0.1-SNAPSHOT/ ) - (I published to the wrong repo initially, oops).

Once this change is merged, all of the repositories with `grailsPublish` will have broken publishing since the urls will be missing. I plan to go through all of them quickly and set the appropriate snapshot url (plugins [go here](https://repo.grails.org/grails/plugins3-snapshots-local) & profiles [go here](https://repo.grails.org/grails/libs-snapshots-local)) to fix this breakage.  Separately, I'll go through the various multi-projects that couldn't use grailsPublish and switch them to grails publish (like the spring security rest plugin).  

As part of the milestone announcement, we can offer these plugins to people so they can use them to simplify plugin upgrades.  I'd like to provide an example github action too.


