### PR TITLE
Replace usages of deprecated `ConfigureUtil`

### DIFF
--- a/src/main/groovy/org/grails/gradle/plugin/core/GrailsExtension.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/core/GrailsExtension.groovy
@@ -3,7 +3,6 @@ package org.grails.gradle.plugin.core
 import groovy.transform.CompileStatic
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.Project
-import org.gradle.util.ConfigureUtil
 
 /**
  * A extension to the Gradle plugin to configure Grails settings
@@ -52,15 +51,20 @@ class GrailsExtension {
      * Configure the reloading agent
      */
     Agent agent(@DelegatesTo(Agent) Closure configurer) {
-        ConfigureUtil.configure(configurer, agent)
+        configurer.delegate = agent
+        configurer.resolveStrategy = Closure.DELEGATE_FIRST
+        configurer.call()
+        return agent
     }
 
     /**
      * Allows defining plugins in the available scopes
      */
     void plugins(Closure pluginDefinitions) {
-        def definer = new PluginDefiner(project,exploded)
-        ConfigureUtil.configureSelf(pluginDefinitions, definer)
+        PluginDefiner definer = new PluginDefiner(project, exploded)
+        pluginDefinitions.delegate = definer
+        pluginDefinitions.resolveStrategy = Closure.DELEGATE_FIRST
+        pluginDefinitions.call()
     }
     /**
      * Configuration for the reloading agent

--- a/src/main/groovy/org/grails/gradle/plugin/publishing/internal/GrailsPublishExtension.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/publishing/internal/GrailsPublishExtension.groovy
@@ -17,7 +17,6 @@
 package org.grails.gradle.plugin.publishing.internal
 
 import groovy.transform.CompileStatic
-import org.gradle.util.ConfigureUtil
 
 /**
  * @author Puneet Behl
@@ -124,7 +123,10 @@ class GrailsPublishExtension {
      * @return the license instance
      */
     License license(@DelegatesTo(License) Closure configurer) {
-        ConfigureUtil.configure(configurer, license)
+        configurer.delegate = license
+        configurer.resolveStrategy = Closure.DELEGATE_FIRST
+        configurer.call()
+        return license
     }
 
     void setLicense(License license) {


### PR DESCRIPTION
The `org.gradle.util.ConfigureUtil` type has been deprecated. This is scheduled to be removed in Gradle 9.0.