### PR TITLE
Ensure Grails plugin `assemble` task produces only a JAR artifact

### DIFF
--- a/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
@@ -24,7 +24,6 @@ import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.internal.tasks.DefaultTaskDependency
-import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.SourceSet
@@ -33,11 +32,9 @@ import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskDependency
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.compile.GroovyCompile
-import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.language.jvm.tasks.ProcessResources
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 import org.grails.gradle.plugin.util.SourceSets
-import org.springframework.boot.gradle.plugin.SpringBootPlugin
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 import javax.inject.Inject
@@ -69,9 +66,11 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
             configureProjectNameAndVersionASTMetadata(project)
         }
 
+        configureAssembleTask(project)
+
         configurePluginResources(project)
 
-        configurePluginJarTask(project)
+        configureJarTask(project)
 
         configureSourcesJarTask(project)
 
@@ -187,17 +186,34 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
         }
     }
 
-    protected void configurePluginJarTask(Project project) {
-        project.tasks.named(SpringBootPlugin.BOOT_JAR_TASK_NAME) { Task bootJarTask ->
-            bootJarTask.enabled = false // Grails Plugins should not produce a bootJar
+    protected void configureAssembleTask(Project project) {
+        // Assemble task in Grails Plugins should only produce a plain jar
+        project.tasks.named('assemble') { Task assembleTask ->
+            def disabledTasks = [
+                'bootDistTar',
+                'bootDistZip',
+                'bootJar',
+                'bootStartScripts',
+                'bootWar',
+                'bootWarMainClassName',
+                'distTar',
+                'distZip',
+                'startScripts',
+                'war'
+            ]
+            disabledTasks.each { String disabledTaskName ->
+                project.tasks.findByName(disabledTaskName)?.enabled = false
+            }
+            // By default the assemble task does not create a plain jar
+            assembleTask.dependsOn('jar')
         }
-        project.tasks.named(JavaPlugin.JAR_TASK_NAME, Jar) { Jar jarTask ->
+    }
+
+    protected void configureJarTask(Project project) {
+        project.tasks.named('jar', Jar) { Jar jarTask ->
             jarTask.enabled = true
             jarTask.archiveClassifier.set('') // Remove '-plain' suffix from jar file name
             jarTask.exclude('application.yml', 'application.groovy', 'logback.groovy', 'logback.xml')
-        }
-        project.tasks.named(LifecycleBasePlugin.ASSEMBLE_TASK_NAME) { Task assembleTask ->
-            assembleTask.dependsOn(JavaPlugin.JAR_TASK_NAME) // assemble task should produce the jar artifact
         }
     }
 

--- a/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
@@ -188,16 +188,16 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
     }
 
     protected void configurePluginJarTask(Project project) {
-        project.tasks.named(SpringBootPlugin.BOOT_JAR_TASK_NAME) {
-            it.enabled = false // Grails Plugins should not produce a bootJar
+        project.tasks.named(SpringBootPlugin.BOOT_JAR_TASK_NAME) { Task bootJarTask ->
+            bootJarTask.enabled = false // Grails Plugins should not produce a bootJar
         }
-        project.tasks.named(JavaPlugin.JAR_TASK_NAME, Jar) {
-            it.enabled = true
-            it.archiveClassifier.set('') // Remove '-plain' suffix from jar file name
-            it.exclude('application.yml', 'application.groovy', 'logback.groovy', 'logback.xml')
+        project.tasks.named(JavaPlugin.JAR_TASK_NAME, Jar) { Jar jarTask ->
+            jarTask.enabled = true
+            jarTask.archiveClassifier.set('') // Remove '-plain' suffix from jar file name
+            jarTask.exclude('application.yml', 'application.groovy', 'logback.groovy', 'logback.xml')
         }
-        project.tasks.named(LifecycleBasePlugin.ASSEMBLE_TASK_NAME) {
-            it.dependsOn(JavaPlugin.JAR_TASK_NAME) // assemble task should produce the jar artifact
+        project.tasks.named(LifecycleBasePlugin.ASSEMBLE_TASK_NAME) { Task assembleTask ->
+            assembleTask.dependsOn(JavaPlugin.JAR_TASK_NAME) // assemble task should produce the jar artifact
         }
     }
 

--- a/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
@@ -33,6 +33,7 @@ import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskDependency
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.compile.GroovyCompile
+import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.language.jvm.tasks.ProcessResources
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 import org.grails.gradle.plugin.util.SourceSets
@@ -194,6 +195,9 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
             it.enabled = true
             it.archiveClassifier.set('') // Remove '-plain' suffix from jar file name
             it.exclude('application.yml', 'application.groovy', 'logback.groovy', 'logback.xml')
+        }
+        project.tasks.named(LifecycleBasePlugin.ASSEMBLE_TASK_NAME) {
+            it.dependsOn(JavaPlugin.JAR_TASK_NAME) // assemble task should produce the jar artifact
         }
     }
 


### PR DESCRIPTION
Previously, running the `assemble` task in a Grails plugin project only generated `*.war` and `*-plain.war` artifacts. This change ensures that the task also produces the expected JAR artifact, aligning with typical plugin packaging needs.