### PR TITLE
Update to 7.0.0-M1 versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 projectVersion=7.0.0-SNAPSHOT
 gradleNexusPluginVersion=2.3.1
 gradleNexusPublishPluginVersion=2.0.0
-grailsVersion=7.0.0-SNAPSHOT
-grailsShellVersion=7.0.0-SNAPSHOT
-springBootVersion=3.4.0
+grailsVersion=7.0.0-M1
+grailsShellVersion=7.0.0-M1
+springBootVersion=3.4.1
 springGradleDependencyManagementVersion=1.1.6
 # Since we're pulling in spring's dependency management, we need to override this to support the groovy version of gradle
 spock.version=2.3-groovy-3.0


### PR DESCRIPTION
This PR is for after the grails-core:7.0.0-M1 release and will fail until then.  