### PR TITLE
Handle no configscript

### DIFF
--- a/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -146,6 +146,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
 
         def configScriptTask = project.tasks.create('configScript')
         def configFile = project.layout.buildDirectory.file('config.groovy')
+        configFile.get().asFile.delete()
         configScriptTask.outputs.file(configFile)
         addJavaTimeImport(project, configScriptTask)
 

--- a/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -151,7 +151,10 @@ class GrailsGradlePlugin extends GroovyPlugin {
 
         project.tasks.withType(GroovyCompile).configureEach { GroovyCompile task ->
             task.dependsOn('configScript')
-            task.groovyOptions.configurationScript = project.tasks.named('configScript').get().outputs.files.singleFile
+            def mergedConfigFile = project.tasks.named('configScript').get().outputs.files.singleFile
+            if (mergedConfigFile.exists()) {
+                task.groovyOptions.configurationScript = mergedConfigFile
+            }
         }
     }
 


### PR DESCRIPTION
Fixes bug where compilation fails if there are no configscript changes.

Related to #388