### PR TITLE
Prevent double registration of configScript task

### DIFF
--- a/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -144,17 +144,18 @@ class GrailsGradlePlugin extends GroovyPlugin {
 
         configurePathingJar(project)
 
-        def configScriptTask = project.tasks.create('configScript')
-        def configFile = project.layout.buildDirectory.file('config.groovy')
-        configFile.get().asFile.delete()
-        configScriptTask.outputs.file(configFile)
-        addJavaTimeImport(project, configScriptTask)
-
-        project.tasks.withType(GroovyCompile).configureEach { GroovyCompile task ->
-            task.dependsOn('configScript')
-            def mergedConfigFile = project.tasks.named('configScript').get().outputs.files.singleFile
-            if (mergedConfigFile.exists()) {
-                task.groovyOptions.configurationScript = mergedConfigFile
+        if (project.tasks.findByName('configScript') == null) {
+            def configScriptTask = project.tasks.create('configScript')
+            def configFile = project.layout.buildDirectory.file('config.groovy')
+            configFile.get().asFile.delete()
+            configScriptTask.outputs.file(configFile)
+            addJavaTimeImport(project, configScriptTask)
+            project.tasks.withType(GroovyCompile).configureEach { GroovyCompile task ->
+                task.dependsOn('configScript')
+                def mergedConfigFile = project.tasks.named('configScript').get().outputs.files.singleFile
+                if (mergedConfigFile.exists()) {
+                    task.groovyOptions.configurationScript = mergedConfigFile
+                }
             }
         }
     }


### PR DESCRIPTION
Add a guard to ensure the configScript task is registered only once, resolving an issue where applying multiple Gradle plugins lead to an error that the task is already created.

Related to #388.