### PR TITLE
Include `testFixtures` configurations in POM version resolution

### DIFF
--- a/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishGradlePlugin.groovy
@@ -360,6 +360,10 @@ Note: if project properties are used, the properties must be defined prior to ap
                                 def artifactId = ((dependencyNode as Node).getAt(artifactIdQName).first() as Node).text()
                                 def resolvedArtifacts = project.configurations.compileClasspath.resolvedConfiguration.resolvedArtifacts +
                                                         project.configurations.runtimeClasspath.resolvedConfiguration.resolvedArtifacts
+                                if (project.configurations.hasProperty('testFixturesCompileClasspath')) {
+                                    resolvedArtifacts += project.configurations.testFixturesCompileClasspath.resolvedConfiguration.resolvedArtifacts +
+                                                         project.configurations.testFixturesRuntimeClasspath.resolvedConfiguration.resolvedArtifacts
+                                }
                                 def managedVersion = resolvedArtifacts.find {
                                     it.moduleVersion.id.group == groupId &&
                                     it.moduleVersion.id.name == artifactId


### PR DESCRIPTION
Previously, only `compileClasspath` and `runtimeClasspath` were used to resolve dependencies. This caused issues with `grails-geb`, which relies on the `testFixtures` Gradle feature.

Now, dependencies defined in `testFixtures` are also included, ensuring proper resolution.