### PR TITLE
Fix ast sources in javadoc & source jars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,11 +65,8 @@ if (isReleaseVersion) {
     apply plugin: 'signing'
 }
 
+compileJava.options.release = 17
 java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
-    }
-
     withJavadocJar()
     withSourcesJar()
 }

--- a/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishGradlePlugin.groovy
@@ -240,14 +240,6 @@ Note: if project properties are used, the properties must be defined prior to ap
                         groupId gpe.groupId ?: project.group
 
                         doAddArtefact(project, delegate)
-                        def sourcesJar = taskContainer.findByName('sourcesJar')
-                        if (sourcesJar != null) {
-                            artifact sourcesJar
-                        }
-                        def javadocJar = taskContainer.findByName('javadocJar')
-                        if (javadocJar != null) {
-                            artifact javadocJar
-                        }
                         def extraArtefact = getDefaultExtraArtifact(project)
                         if (extraArtefact) {
                             artifact extraArtefact


### PR DESCRIPTION
I couldn't figure out why the AST files weren't being included in the source or javadoc jars.  Turns out it's because we're searching for the tasks immediately, so if they weren't defined prior to the gradle plugin being applied, they wouldn't get included.  This PR changes those tasks to be run after evaluation, which means you can now use composition in your gradle files and the task will be found correctly.

This PR also fixes the publish plugin so that it doesn't try to add the task artifacts - when you invoke `publication.from project.components.java` that will add the source jars, javadoc, and class jars.  There's no reason to add them again.  This actually causes withSourceJars() & withJavadocJar() to fail if defined.

This PR also moves away from toolchain so the matrix builds work correctly & use the right version of java.