### PR TITLE
Improve the publishing plugin to ensure sources & javadoc are published by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ grails-publish
 ---------
 A Gradle plugin to ease publishing with the maven publish plugin or the nexus publish plugin.
 
+Artifacts published by this plugin include sources, the jar file, and a javadoc jar that contains both the groovydoc & javadoc.
+
 Example Usage:
 
     grailsPublish {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,12 @@ springBootVersion=3.4.2
 springGradleDependencyManagementVersion=1.1.6
 # Since we're pulling in spring's dependency management, we need to override this to support the groovy version of gradle
 spock.version=2.3-groovy-3.0
+
+# This groovy version should be the version built with grails applications and NOT the one used by this project
+# since this project must use gradle's groovy version.  This property will be used to set up the test projects
+# like grails would be to ensure proper test coverage
+e2eGroovyVersion=4.0.24
+
 org.gradle.caching=true
 org.gradle.daemon=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx1536M -XX:MaxMetaspaceSize=512M

--- a/gradle/e2eTest.gradle
+++ b/gradle/e2eTest.gradle
@@ -6,6 +6,7 @@ def e2eTestTask = tasks.register('e2eTest', Test) {
     useJUnitPlatform()
     systemProperty("localMavenPath", rootProject.layout.buildDirectory.dir('local-maven').get().asFile.absolutePath)
     systemProperty("grailsGradlePluginVersion", rootProject.version)
+    systemProperty("groovyVersion", e2eGroovyVersion)
 
     testLogging {
         exceptionFormat = 'full'

--- a/src/e2eTest/groovy/org/grails/gradle/test/GradleSpecification.groovy
+++ b/src/e2eTest/groovy/org/grails/gradle/test/GradleSpecification.groovy
@@ -21,7 +21,10 @@ abstract class GradleSpecification extends Specification {
         gradleRunner = GradleRunner.create()
                 .withPluginClasspath()
                 .withTestKitDir(testKitDirectory.toFile())
+    }
 
+    void setup() {
+        gradleRunner.environment?.clear()
         gradleRunner = addEnvironmentVariable(
                 "LOCAL_MAVEN_PATH",
                 System.getProperty("localMavenPath"),

--- a/src/e2eTest/groovy/org/grails/gradle/test/GradleSpecification.groovy
+++ b/src/e2eTest/groovy/org/grails/gradle/test/GradleSpecification.groovy
@@ -36,6 +36,12 @@ abstract class GradleSpecification extends Specification {
                 System.getProperty("grailsGradlePluginVersion"),
                 gradleRunner
         )
+
+        gradleRunner = setGradleProperty(
+                "groovyVersion",
+                System.getProperty("groovyVersion"),
+                gradleRunner
+        )
     }
 
     GradleRunner addEnvironmentVariable(String key, String value, GradleRunner runner) {

--- a/src/e2eTest/groovy/org/grails/gradle/test/GrailsPublishPluginSpec.groovy
+++ b/src/e2eTest/groovy/org/grails/gradle/test/GrailsPublishPluginSpec.groovy
@@ -483,7 +483,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
             }
 
             dependencies {
-                implementation 'org.apache.groovy:groovy-all:4.0.24'
+                implementation "org.apache.groovy:groovy-all:\$groovyVersion"
             }
         
             apply plugin: 'org.grails.grails-publish'

--- a/src/e2eTest/groovy/org/grails/gradle/test/GrailsPublishPluginSpec.groovy
+++ b/src/e2eTest/groovy/org/grails/gradle/test/GrailsPublishPluginSpec.groovy
@@ -4,9 +4,24 @@ import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import spock.lang.PendingFeature
 
+import java.nio.file.Files
 import java.nio.file.Path
+import java.util.jar.JarEntry
+import java.util.jar.JarFile
 
 class GrailsPublishPluginSpec extends GradleSpecification {
+    List<File> toCleanup = []
+
+    def cleanup() {
+        for (File file : toCleanup) {
+            try {
+                file.deleteDir()
+            }
+            catch(ignored) {
+            }
+        }
+    }
+
     def "gradle config works when not publishing - snapshot - maven publish - legacy-apply - multi-project-no-subproject-build-gradle-publish-all"() {
         given:
         GradleRunner runner = setupTestResourceProject('legacy-apply', 'multi-project-no-subproject-build-gradle-publish-all')
@@ -16,7 +31,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         assertTaskSuccess("assemble", result)
-        assertBuildSuccess(result, ["compileJava", "processResources"])
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar"])
 
         !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
         !result.output.contains("Environment Variable `GRAILS_PUBLISH_RELEASE` detected - using variable instead of project version.")
@@ -35,7 +50,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         assertTaskSuccess("assemble", result)
-        assertBuildSuccess(result, ["compileJava", "processResources"])
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar"])
 
         !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
     }
@@ -49,7 +64,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         assertTaskSuccess("assemble", result)
-        assertBuildSuccess(result, ["compileJava", "processResources"])
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar"])
 
         !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
     }
@@ -63,7 +78,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         assertTaskSuccess("assemble", result)
-        assertBuildSuccess(result, ["compileJava", "processResources"])
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar"])
 
         !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
     }
@@ -77,7 +92,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         assertTaskSuccess("assemble", result)
-        assertBuildSuccess(result, ["compileJava", "processResources"])
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar"])
 
         !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
     }
@@ -91,7 +106,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         assertTaskSuccess("assemble", result)
-        assertBuildSuccess(result, ["compileJava", "processResources"])
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar"])
 
         !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
     }
@@ -105,7 +120,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         assertTaskSuccess("assemble", result)
-        assertBuildSuccess(result, ["compileJava", "processResources"])
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar"])
 
         !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
     }
@@ -119,7 +134,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         assertTaskSuccess("assemble", result)
-        assertBuildSuccess(result, ["compileJava", "processResources"])
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar"])
 
         !result.output.contains("Project subproject2 does not have a version defined. Using the gradle property `projectVersion` to assume version is 0.0.1-SNAPSHOT.")
         result.output.contains("Project subproject1 does not have a version defined. Using the gradle property `projectVersion` to assume version is 0.0.1-SNAPSHOT.")
@@ -134,7 +149,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         assertTaskSuccess("assemble", result)
-        assertBuildSuccess(result, ["compileJava", "processResources"])
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar"])
 
         !result.output.contains("Project subproject2 does not have a version defined. Using the gradle property `projectVersion` to assume version is 0.0.1-SNAPSHOT.")
         result.output.contains("Project subproject1 does not have a version defined. Using the gradle property `projectVersion` to assume version is 0.0.1-SNAPSHOT.")
@@ -149,7 +164,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         assertTaskSuccess("assemble", result)
-        assertBuildSuccess(result, ["compileJava", "processResources"])
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar"])
 
         !result.output.contains("Project subproject2 does not have a version defined. Using the gradle property `projectVersion` to assume version is 0.0.1-SNAPSHOT.")
         result.output.contains("Project subproject1 does not have a version defined. Using the gradle property `projectVersion` to assume version is 0.0.1-SNAPSHOT.")
@@ -164,7 +179,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         assertTaskSuccess("assemble", result)
-        assertBuildSuccess(result, ["compileJava", "processResources"])
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar"])
 
         !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
     }
@@ -178,7 +193,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         assertTaskSuccess("assemble", result)
-        assertBuildSuccess(result, ["compileJava", "processResources"])
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar"])
 
         !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
     }
@@ -198,7 +213,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         assertTaskSuccess("assemble", result)
-        assertBuildSuccess(result, ["compileJava", "processResources"])
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar"])
 
         !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
     }
@@ -218,7 +233,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         assertTaskSuccess("assemble", result)
-        assertBuildSuccess(result, ["compileJava", "processResources"])
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar"])
 
         !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
     }
@@ -238,7 +253,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         assertTaskSuccess("assemble", result)
-        assertBuildSuccess(result, ["compileJava", "processResources"])
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar"])
 
         !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
     }
@@ -258,7 +273,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         assertTaskSuccess("assemble", result)
-        assertBuildSuccess(result, ["compileJava", "processResources"])
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar"])
 
         !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
     }
@@ -278,7 +293,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         assertTaskSuccess("assemble", result)
-        assertBuildSuccess(result, ["compileJava", "processResources"])
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar"])
 
         !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
     }
@@ -299,7 +314,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         assertTaskSuccess("assemble", result)
-        assertBuildSuccess(result, ["compileJava", "processResources"])
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar"])
 
         !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
     }
@@ -320,7 +335,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         assertTaskSuccess("assemble", result)
-        assertBuildSuccess(result, ["compileJava", "processResources"])
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar"])
 
         !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
     }
@@ -340,7 +355,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         assertTaskSuccess("assemble", result)
-        assertBuildSuccess(result, ["compileJava", "processResources"])
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar"])
 
         result.output.contains("Project subproject1 does not have a version defined. Using the gradle property `projectVersion` to assume version is 0.0.1-M1.")
     }
@@ -360,7 +375,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         assertTaskSuccess("assemble", result)
-        assertBuildSuccess(result, ["compileJava", "processResources"])
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar"])
 
         result.output.contains("Project subproject1 does not have a version defined. Using the gradle property `projectVersion` to assume version is 0.0.1-M1.")
     }
@@ -380,7 +395,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         assertTaskSuccess("assemble", result)
-        assertBuildSuccess(result, ["compileJava", "processResources"])
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar"])
 
         result.output.contains("Project subproject1 does not have a version defined. Using the gradle property `projectVersion` to assume version is 0.0.1-M1.")
     }
@@ -401,7 +416,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         assertTaskSuccess("assemble", result)
-        assertBuildSuccess(result, ["compileJava", "processResources"])
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar"])
 
         !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
     }
@@ -422,7 +437,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         assertTaskSuccess("assemble", result)
-        assertBuildSuccess(result, ["compileJava", "processResources"])
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar"])
 
         !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
     }
@@ -490,7 +505,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         assertTaskSuccess("assemble", assembleResult)
-        assertBuildSuccess(assembleResult, ["compileJava", "processResources"])
+        assertBuildSuccess(assembleResult, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar"])
 
         when:
         runner = addEnvironmentVariable("MAVEN_PUBLISH_USERNAME", "publishUser", runner)
@@ -503,7 +518,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
         bf.buildResult.output.contains("Could not locate a project property of `mavenPublishUrl` or an environment variable of `MAVEN_PUBLISH_URL`. A URL is required for maven publishing.")
     }
 
-    def "project without sources fails grailsPublish apply"() {
+    def "project without java plugin fails grailsPublish apply"() {
         given:
         Path projectDir = createProjectDir("invalid-sources")
 
@@ -534,7 +549,42 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         UnexpectedBuildFailure bf = thrown(UnexpectedBuildFailure)
-        bf.buildResult.output.contains("Cannot apply Grails Publish Plugin. Project invalid-sources does not have any components to publish.")
+        bf.buildResult.output.contains("Grails Publish Plugin requires the Java Plugin to be applied to the project.")
+    }
+
+    def "project without sources fails grailsPublish apply"() {
+        given:
+        Path projectDir = createProjectDir("invalid-sources")
+
+        GradleRunner runner = setupProject(projectDir)
+
+        projectDir.resolve("settings.gradle").toFile().text = """
+            rootProject.name = 'invalid-sources'
+        """
+
+        projectDir.resolve('build.gradle').toFile().text = """
+            buildscript {
+                repositories {
+                    maven { url "\${System.getenv('LOCAL_MAVEN_PATH')}\" }
+                    maven { url = 'https://repo.grails.org/grails/core' }
+                }
+                dependencies {
+                    classpath "org.grails:grails-gradle-plugin:\$grailsGradlePluginVersion"
+                }
+            }
+            
+            version "0.0.1"
+            
+            apply plugin: 'java'
+            apply plugin: 'org.grails.grails-publish'
+        """
+
+        when:
+        executeTask("assemble", runner)
+
+        then:
+        UnexpectedBuildFailure bf = thrown(UnexpectedBuildFailure)
+        bf.buildResult.output.contains("Cannot apply Grails Publish Plugin. Project invalid-sources does not have anything to publish.")
     }
 
     def "project with environment variable based snapshot or release detection - is snapshot"() {
@@ -549,7 +599,7 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         assertTaskSuccess("assemble", result)
-        assertBuildSuccess(result, ["compileJava", "processResources"])
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar"])
 
         !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
         result.output.contains("Environment Variable `GRAILS_PUBLISH_RELEASE` detected - using variable instead of project version.")
@@ -569,11 +619,421 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         then:
         assertTaskSuccess("assemble", result)
-        assertBuildSuccess(result, ["compileJava", "processResources"])
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar"])
 
         !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
         result.output.contains("Environment Variable `GRAILS_PUBLISH_RELEASE` detected - using variable instead of project version.")
         result.output.contains("Project subproject1 will be a release.")
         result.output.contains("Project subproject2 will be a release.")
+    }
+
+    def "source artifact test - simple project"() {
+        given:
+        File tempDir = File.createTempDir("simple-project")
+        toCleanup << tempDir
+
+        and:
+        GradleRunner runner = setupTestResourceProject('other-artifacts', 'simple-project')
+
+        runner = setGradleProperty("projectVersion", "0.0.1-SNAPSHOT", runner)
+        runner = setGradleProperty("mavenPublishUrl", tempDir.toPath().toAbsolutePath().toString(), runner)
+        runner = addEnvironmentVariable("GRAILS_PUBLISH_RELEASE", "false", runner)
+
+        when:
+        def result = executeTask("publish", ["--info"], runner)
+
+        then:
+        assertTaskSuccess("sourcesJar", result)
+        assertTaskSuccess("javadocJar", result)
+        assertTaskSuccess("groovydoc", result)
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar", "generateMetadataFileForMavenPublication", "generatePomFileForMavenPublication", "publishMavenPublicationToMavenLocal", "publishToMavenLocal"])
+
+        !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
+        result.output.contains("Environment Variable `GRAILS_PUBLISH_RELEASE` detected - using variable instead of project version.")
+
+        and:
+        Path artifactDir = tempDir.toPath().resolve("org/grails/example/simple-project/0.0.1-SNAPSHOT")
+        Files.exists(artifactDir)
+        File[] artifacts = artifactDir.toFile().listFiles()
+
+        /*
+        simple-project-0.0.1-20250212.043425-1.pom.sha1
+        simple-project-0.0.1-20250212.043425-1.pom.md5
+        simple-project-0.0.1-20250212.043425-1-javadoc.jar.sha1
+        simple-project-0.0.1-20250212.043425-1.module.md5
+        simple-project-0.0.1-20250212.043425-1-sources.jar.md5
+        simple-project-0.0.1-20250212.043425-1.jar.md5
+        maven-metadata.xml
+        simple-project-0.0.1-20250212.043425-1.module
+        simple-project-0.0.1-20250212.043425-1.pom
+        simple-project-0.0.1-20250212.043425-1.jar.sha1
+        simple-project-0.0.1-20250212.043425-1-javadoc.jar
+        simple-project-0.0.1-20250212.043425-1-sources.jar
+        simple-project-0.0.1-20250212.043425-1.jar
+        simple-project-0.0.1-20250212.043425-1.module.sha1
+        simple-project-0.0.1-20250212.043425-1-sources.jar.sha1
+        maven-metadata.xml.md5
+        simple-project-0.0.1-20250212.043425-1-javadoc.jar.md5
+        maven-metadata.xml.sha1
+         */
+
+        File javadocJar = artifacts.find{ it.name.endsWith("javadoc.jar") }
+        javadocJar
+        findJarFileEntry("TestJava.html", javadocJar)
+        findJarFileEntry("org/grails/example/MyProject.html", javadocJar)
+
+        File sourcesJar = artifacts.find{ it.name.endsWith("sources.jar") }
+        sourcesJar
+        findJarFileEntry("TestJava.java", sourcesJar)
+        findJarFileEntry("org/grails/example/MyProject.groovy", sourcesJar)
+
+        File classesJar = artifacts.find{ it.name.endsWith(".jar") && !it.name.endsWith("javadoc.jar") && !it.name.endsWith("sources.jar") }
+        classesJar
+        findJarFileEntry("TestJava.class", classesJar)
+        findJarFileEntry("org/grails/example/MyProject.class", classesJar)
+    }
+
+    boolean findJarFileEntry(String path, File file) {
+        try (JarFile jarFile = new JarFile(file)) {
+            return jarFile.getEntry(path) != null
+        }
+    }
+
+    def "source artifact test - java already configured"() {
+        given:
+        File tempDir = File.createTempDir("java-already-configured")
+        toCleanup << tempDir
+
+        and:
+        GradleRunner runner = setupTestResourceProject('other-artifacts', 'java-already-configured')
+
+        runner = setGradleProperty("projectVersion", "0.0.1-SNAPSHOT", runner)
+        runner = setGradleProperty("mavenPublishUrl", tempDir.toPath().toAbsolutePath().toString(), runner)
+        runner = addEnvironmentVariable("GRAILS_PUBLISH_RELEASE", "false", runner)
+
+        when:
+        def result = executeTask("publish", ["--info"], runner)
+
+        then:
+        assertTaskSuccess("sourcesJar", result)
+        assertTaskSuccess("javadocJar", result)
+        assertTaskSuccess("groovydoc", result)
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar", "generateMetadataFileForMavenPublication", "generatePomFileForMavenPublication", "publishMavenPublicationToMavenLocal", "publishToMavenLocal"])
+
+        !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
+        result.output.contains("Environment Variable `GRAILS_PUBLISH_RELEASE` detected - using variable instead of project version.")
+
+        and:
+        Path artifactDir = tempDir.toPath().resolve("org/grails/example/java-already-configured/0.0.1-SNAPSHOT")
+        Files.exists(artifactDir)
+        File[] artifacts = artifactDir.toFile().listFiles()
+
+        File javadocJar = artifacts.find{ it.name.endsWith("javadoc.jar") }
+        javadocJar
+        findJarFileEntry("TestJava.html", javadocJar)
+        findJarFileEntry("org/grails/example/MyProject.html", javadocJar)
+
+        File sourcesJar = artifacts.find{ it.name.endsWith("sources.jar") }
+        sourcesJar
+        findJarFileEntry("TestJava.java", sourcesJar)
+        findJarFileEntry("org/grails/example/MyProject.groovy", sourcesJar)
+
+        File classesJar = artifacts.find{ it.name.endsWith(".jar") && !it.name.endsWith("javadoc.jar") && !it.name.endsWith("sources.jar") }
+        classesJar
+        findJarFileEntry("TestJava.class", classesJar)
+        findJarFileEntry("org/grails/example/MyProject.class", classesJar)
+    }
+
+    def "source artifact test - groovydoc disabled"() {
+        given:
+        File tempDir = File.createTempDir("groovy-doc-disabled")
+        toCleanup << tempDir
+
+        and:
+        GradleRunner runner = setupTestResourceProject('other-artifacts', 'groovy-doc-disabled')
+
+        runner = setGradleProperty("projectVersion", "0.0.1-SNAPSHOT", runner)
+        runner = setGradleProperty("mavenPublishUrl", tempDir.toPath().toAbsolutePath().toString(), runner)
+        runner = addEnvironmentVariable("GRAILS_PUBLISH_RELEASE", "false", runner)
+
+        when:
+        executeTask("publish", ["--info"], runner)
+
+        then:
+        Exception e = thrown(Exception)
+        e.message.contains("Groovydoc task is disabled. Please enable it to ensure javadoc can be published correctly with the Grails Publish Plugin.")
+    }
+
+    def "source artifact test - java only project"() {
+        given:
+        File tempDir = File.createTempDir("java-only-project")
+        toCleanup << tempDir
+
+        and:
+        GradleRunner runner = setupTestResourceProject('other-artifacts', 'java-only-project')
+
+        runner = setGradleProperty("projectVersion", "0.0.1-SNAPSHOT", runner)
+        runner = setGradleProperty("mavenPublishUrl", tempDir.toPath().toAbsolutePath().toString(), runner)
+        runner = addEnvironmentVariable("GRAILS_PUBLISH_RELEASE", "false", runner)
+
+        when:
+        def result = executeTask("publish", ["--info"], runner)
+
+        then:
+        assertTaskSuccess("sourcesJar", result)
+        assertTaskSuccess("javadocJar", result)
+        assertBuildSuccess(result, ["compileJava", "processResources", "classes", "jar", "javadoc", "javadocJar", "sourcesJar", "generateMetadataFileForMavenPublication", "generatePomFileForMavenPublication", "publishMavenPublicationToMavenLocal", "publishToMavenLocal"])
+
+        !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
+        result.output.contains("Environment Variable `GRAILS_PUBLISH_RELEASE` detected - using variable instead of project version.")
+
+        and:
+        Path artifactDir = tempDir.toPath().resolve("org/grails/example/java-only-project/0.0.1-SNAPSHOT")
+        Files.exists(artifactDir)
+        File[] artifacts = artifactDir.toFile().listFiles()
+
+        File javadocJar = artifacts.find{ it.name.endsWith("javadoc.jar") }
+        javadocJar
+        findJarFileEntry("TestJava.html", javadocJar)
+
+        File sourcesJar = artifacts.find{ it.name.endsWith("sources.jar") }
+        sourcesJar
+        findJarFileEntry("TestJava.java", sourcesJar)
+
+        File classesJar = artifacts.find{ it.name.endsWith(".jar") && !it.name.endsWith("javadoc.jar") && !it.name.endsWith("sources.jar") }
+        classesJar
+        findJarFileEntry("TestJava.class", classesJar)
+    }
+
+    def "source artifact test - non-groovy-java-sources are published"() {
+        given:
+        File tempDir = File.createTempDir("non-groovy-java-sources-included")
+        toCleanup << tempDir
+
+        and:
+        GradleRunner runner = setupTestResourceProject('other-artifacts', 'non-groovy-java-sources-included')
+
+        runner = setGradleProperty("projectVersion", "0.0.1-SNAPSHOT", runner)
+        runner = setGradleProperty("mavenPublishUrl", tempDir.toPath().toAbsolutePath().toString(), runner)
+        runner = addEnvironmentVariable("GRAILS_PUBLISH_RELEASE", "false", runner)
+
+        when:
+        def result = executeTask("publish", ["--info"], runner)
+
+        then:
+        assertTaskSuccess("sourcesJar", result)
+        assertTaskSuccess("javadocJar", result)
+        assertBuildSuccess(result, ["compileJava", "processResources", "classes", "jar", "javadoc", "javadocJar", "sourcesJar", "generateMetadataFileForMavenPublication", "generatePomFileForMavenPublication", "publishMavenPublicationToMavenLocal", "publishToMavenLocal"])
+
+        !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
+        result.output.contains("Environment Variable `GRAILS_PUBLISH_RELEASE` detected - using variable instead of project version.")
+
+        and:
+        System.out.println(tempDir.list())
+        Path artifactDir = tempDir.toPath().resolve("org/grails/example/non-groovy-java-sources-included/0.0.1-SNAPSHOT")
+        Files.exists(artifactDir)
+        File[] artifacts = artifactDir.toFile().listFiles()
+
+        File javadocJar = artifacts.find{ it.name.endsWith("javadoc.jar") }
+        javadocJar
+        findJarFileEntry("TestJava.html", javadocJar)
+
+        File sourcesJar = artifacts.find{ it.name.endsWith("sources.jar") }
+        sourcesJar
+        findJarFileEntry("TestJava.java", sourcesJar)
+        findJarFileEntry("Testing.txt", sourcesJar)
+
+        File classesJar = artifacts.find{ it.name.endsWith(".jar") && !it.name.endsWith("javadoc.jar") && !it.name.endsWith("sources.jar") }
+        classesJar
+        findJarFileEntry("TestJava.class", classesJar)
+    }
+
+    def "source artifact test - multi project plugins configured in child"() {
+        given:
+        File tempDir = File.createTempDir("multi-project-plugins-applied-child")
+        toCleanup << tempDir
+
+        and:
+        GradleRunner runner = setupTestResourceProject('other-artifacts', 'multi-project-plugins-applied-child')
+
+        runner = setGradleProperty("projectVersion", "0.0.1-SNAPSHOT", runner)
+        runner = setGradleProperty("mavenPublishUrl", tempDir.toPath().toAbsolutePath().toString(), runner)
+        runner = addEnvironmentVariable("GRAILS_PUBLISH_RELEASE", "false", runner)
+
+        when:
+        def result = executeTask("publish", ["--info"], runner)
+
+        then:
+        assertTaskSuccess("sourcesJar", result)
+        assertTaskSuccess("javadocJar", result)
+        assertBuildSuccess(result, ["compileJava", "processResources", "classes", "jar", "javadoc", "javadocJar", "sourcesJar", "generateMetadataFileForMavenPublication", "generatePomFileForMavenPublication", "publishMavenPublicationToMavenLocal", "publishToMavenLocal"])
+
+        !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
+        result.output.contains("Environment Variable `GRAILS_PUBLISH_RELEASE` detected - using variable instead of project version.")
+
+        and:
+        Path subproject2Path = tempDir.toPath().resolve("org/grails/example/subproject2/0.0.1-SNAPSHOT")
+        !Files.exists(subproject2Path)
+
+        and:
+        Path artifactDir = tempDir.toPath().resolve("org/grails/example/subproject1/0.0.1-SNAPSHOT")
+        Files.exists(artifactDir)
+        File[] artifacts = artifactDir.toFile().listFiles()
+
+        File javadocJar = artifacts.find{ it.name.endsWith("javadoc.jar") }
+        javadocJar
+        findJarFileEntry("TestJava.html", javadocJar)
+        findJarFileEntry("org/grails/example/SubProject1.html", javadocJar)
+        !findJarFileEntry("org/grails/example/SubProject2.html", javadocJar)
+
+        File sourcesJar = artifacts.find{ it.name.endsWith("sources.jar") }
+        sourcesJar
+        findJarFileEntry("TestJava.java", sourcesJar)
+        findJarFileEntry("org/grails/example/SubProject1.groovy", sourcesJar)
+        !findJarFileEntry("org/grails/example/SubProject2.groovy", sourcesJar)
+
+        File classesJar = artifacts.find{ it.name.endsWith(".jar") && !it.name.endsWith("javadoc.jar") && !it.name.endsWith("sources.jar") }
+        classesJar
+        findJarFileEntry("TestJava.class", classesJar)
+        findJarFileEntry("org/grails/example/SubProject1.class", classesJar)
+        !findJarFileEntry("org/grails/example/SubProject2.class", classesJar)
+    }
+
+    def "source artifact test - multi project plugins configured in parent"() {
+        given:
+        File tempDir = File.createTempDir("multi-project-plugins-applied-parent")
+        toCleanup << tempDir
+
+        and:
+        GradleRunner runner = setupTestResourceProject('other-artifacts', 'multi-project-plugins-applied-parent')
+
+        runner = setGradleProperty("projectVersion", "0.0.1-SNAPSHOT", runner)
+        runner = setGradleProperty("mavenPublishUrl", tempDir.toPath().toAbsolutePath().toString(), runner)
+        runner = addEnvironmentVariable("GRAILS_PUBLISH_RELEASE", "false", runner)
+
+        when:
+        def result = executeTask("publish", ["--info"], runner)
+
+        then:
+        assertTaskSuccess("sourcesJar", result)
+        assertTaskSuccess("javadocJar", result)
+        assertBuildSuccess(result, ["compileJava", "processResources", "classes", "jar", "javadoc", "javadocJar", "sourcesJar", "generateMetadataFileForMavenPublication", "generatePomFileForMavenPublication", "publishMavenPublicationToMavenLocal", "publishToMavenLocal"])
+
+        !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
+        result.output.contains("Environment Variable `GRAILS_PUBLISH_RELEASE` detected - using variable instead of project version.")
+
+        and:
+        Path subproject2Path = tempDir.toPath().resolve("org/grails/example/subproject2/0.0.1-SNAPSHOT")
+        !Files.exists(subproject2Path)
+
+        and:
+        Path artifactDir = tempDir.toPath().resolve("org/grails/example/subproject1/0.0.1-SNAPSHOT")
+        Files.exists(artifactDir)
+        File[] artifacts = artifactDir.toFile().listFiles()
+
+        File javadocJar = artifacts.find{ it.name.endsWith("javadoc.jar") }
+        javadocJar
+        findJarFileEntry("TestJava.html", javadocJar)
+        findJarFileEntry("org/grails/example/SubProject1.html", javadocJar)
+        !findJarFileEntry("org/grails/example/SubProject2.html", javadocJar)
+
+        File sourcesJar = artifacts.find{ it.name.endsWith("sources.jar") }
+        sourcesJar
+        findJarFileEntry("TestJava.java", sourcesJar)
+        findJarFileEntry("org/grails/example/SubProject1.groovy", sourcesJar)
+        !findJarFileEntry("org/grails/example/SubProject2.groovy", sourcesJar)
+
+        File classesJar = artifacts.find{ it.name.endsWith(".jar") && !it.name.endsWith("javadoc.jar") && !it.name.endsWith("sources.jar") }
+        classesJar
+        findJarFileEntry("TestJava.class", classesJar)
+        findJarFileEntry("org/grails/example/SubProject1.class", classesJar)
+        !findJarFileEntry("org/grails/example/SubProject2.class", classesJar)
+    }
+
+    def "source artifact test - explicit jar creation without gradle assistance"() {
+        given:
+        File tempDir = File.createTempDir("explicit-jar-creation-without-gradle-assistance")
+        toCleanup << tempDir
+
+        and:
+        GradleRunner runner = setupTestResourceProject('other-artifacts', 'explicit-jar-creation-without-gradle-assistance')
+
+        runner = setGradleProperty("projectVersion", "0.0.1-SNAPSHOT", runner)
+        runner = setGradleProperty("mavenPublishUrl", tempDir.toPath().toAbsolutePath().toString(), runner)
+        runner = addEnvironmentVariable("GRAILS_PUBLISH_RELEASE", "false", runner)
+
+        when:
+        def result = executeTask("publish", ["--info"], runner)
+
+        then:
+        assertTaskSuccess("sourcesJar", result)
+        assertTaskSuccess("javadocJar", result)
+        assertTaskSuccess("groovydoc", result)
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar", "generateMetadataFileForMavenPublication", "generatePomFileForMavenPublication", "publishMavenPublicationToMavenLocal", "publishToMavenLocal"])
+
+        !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
+        result.output.contains("Environment Variable `GRAILS_PUBLISH_RELEASE` detected - using variable instead of project version.")
+
+        and:
+        Path artifactDir = tempDir.toPath().resolve("org/grails/example/explicit-jar-creation-without-gradle-assistance/0.0.1-SNAPSHOT")
+        Files.exists(artifactDir)
+        File[] artifacts = artifactDir.toFile().listFiles()
+
+        File javadocJar = artifacts.find{ it.name.endsWith("javadoc.jar") }
+        javadocJar
+        findJarFileEntry("TestJava.html", javadocJar)
+        findJarFileEntry("org/grails/example/MyProject.html", javadocJar)
+
+        File sourcesJar = artifacts.find{ it.name.endsWith("sources.jar") }
+        sourcesJar
+        findJarFileEntry("TestJava.java", sourcesJar)
+        findJarFileEntry("org/grails/example/MyProject.groovy", sourcesJar)
+
+        File classesJar = artifacts.find{ it.name.endsWith(".jar") && !it.name.endsWith("javadoc.jar") && !it.name.endsWith("sources.jar") }
+        classesJar
+        findJarFileEntry("TestJava.class", classesJar)
+        findJarFileEntry("org/grails/example/MyProject.class", classesJar)
+    }
+
+    def "source artifact test - groovy only project"() {
+        given:
+        File tempDir = File.createTempDir("groovy-only-project")
+        toCleanup << tempDir
+
+        and:
+        GradleRunner runner = setupTestResourceProject('other-artifacts', 'groovy-only-project')
+
+        runner = setGradleProperty("projectVersion", "0.0.1-SNAPSHOT", runner)
+        runner = setGradleProperty("mavenPublishUrl", tempDir.toPath().toAbsolutePath().toString(), runner)
+        runner = addEnvironmentVariable("GRAILS_PUBLISH_RELEASE", "false", runner)
+
+        when:
+        def result = executeTask("publish", ["--info"], runner)
+
+        then:
+        assertTaskSuccess("sourcesJar", result)
+        assertTaskSuccess("javadocJar", result)
+        assertTaskSuccess("groovydoc", result)
+        assertBuildSuccess(result, ["compileJava", "compileGroovy", "processResources", "classes", "jar", "groovydoc", "javadoc", "javadocJar", "sourcesJar", "generateMetadataFileForMavenPublication", "generatePomFileForMavenPublication", "publishMavenPublicationToMavenLocal", "publishToMavenLocal"])
+
+        !result.output.contains("does not have a version defined. Using the gradle property `projectVersion` to assume version is ")
+        result.output.contains("Environment Variable `GRAILS_PUBLISH_RELEASE` detected - using variable instead of project version.")
+
+        and:
+        Path artifactDir = tempDir.toPath().resolve("org/grails/example/groovy-only-project/0.0.1-SNAPSHOT")
+        Files.exists(artifactDir)
+        File[] artifacts = artifactDir.toFile().listFiles()
+
+        File javadocJar = artifacts.find{ it.name.endsWith("javadoc.jar") }
+        javadocJar
+        findJarFileEntry("org/grails/example/MyProject.html", javadocJar)
+
+        File sourcesJar = artifacts.find{ it.name.endsWith("sources.jar") }
+        sourcesJar
+        findJarFileEntry("org/grails/example/MyProject.groovy", sourcesJar)
+
+        File classesJar = artifacts.find{ it.name.endsWith(".jar") && !it.name.endsWith("javadoc.jar") && !it.name.endsWith("sources.jar") }
+        classesJar
+        findJarFileEntry("org/grails/example/MyProject.class", classesJar)
     }
 }

--- a/src/e2eTest/resources/publish-projects/legacy-apply/child-project-with-unrelated-parent/build.gradle
+++ b/src/e2eTest/resources/publish-projects/legacy-apply/child-project-with-unrelated-parent/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'java-library'
 apply plugin: 'groovy'
 
 dependencies {
-    implementation 'org.apache.groovy:groovy-all:4.0.24'
+    implementation "org.apache.groovy:groovy-all:$groovyVersion"
 }
 
 apply plugin: 'org.grails.grails-publish'

--- a/src/e2eTest/resources/publish-projects/legacy-apply/child-project-with-unrelated-parent/otherProject/build.gradle
+++ b/src/e2eTest/resources/publish-projects/legacy-apply/child-project-with-unrelated-parent/otherProject/build.gradle
@@ -9,6 +9,6 @@ apply plugin: 'java-library'
 apply plugin: 'groovy'
 
 dependencies {
-    implementation 'org.apache.groovy:groovy-all:4.0.24'
+    implementation "org.apache.groovy:groovy-all:$groovyVersion"
     implementation 'org.grails.example:subproject1'
 }

--- a/src/e2eTest/resources/publish-projects/legacy-apply/multi-project-no-subproject-build-gradle-publish-all/build.gradle
+++ b/src/e2eTest/resources/publish-projects/legacy-apply/multi-project-no-subproject-build-gradle-publish-all/build.gradle
@@ -23,7 +23,7 @@ subprojects { project ->
     }
 
     dependencies {
-        implementation 'org.apache.groovy:groovy-all:4.0.24'
+        implementation "org.apache.groovy:groovy-all:$groovyVersion"
     }
 
     apply plugin: 'org.grails.grails-publish'

--- a/src/e2eTest/resources/publish-projects/legacy-apply/multi-project-no-subproject-build-gradle-publish-per-project/build.gradle
+++ b/src/e2eTest/resources/publish-projects/legacy-apply/multi-project-no-subproject-build-gradle-publish-per-project/build.gradle
@@ -23,7 +23,7 @@ subprojects { project ->
     }
 
     dependencies {
-        implementation 'org.apache.groovy:groovy-all:4.0.24'
+        implementation "org.apache.groovy:groovy-all:$groovyVersion"
     }
 
     if(project.name == "subproject1") {

--- a/src/e2eTest/resources/publish-projects/legacy-apply/multi-project-parent-child-setup-per-project-child-published/build.gradle
+++ b/src/e2eTest/resources/publish-projects/legacy-apply/multi-project-parent-child-setup-per-project-child-published/build.gradle
@@ -21,7 +21,7 @@ apply plugin: 'java-library'
 apply plugin: 'groovy'
 
 dependencies {
-    implementation 'org.apache.groovy:groovy-all:4.0.24'
+    implementation "org.apache.groovy:groovy-all:$groovyVersion"
 }
 
 subprojects { project ->

--- a/src/e2eTest/resources/publish-projects/legacy-apply/multi-project-parent-child-setup-per-project-child-published/subproject2/build.gradle
+++ b/src/e2eTest/resources/publish-projects/legacy-apply/multi-project-parent-child-setup-per-project-child-published/subproject2/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    implementation 'org.apache.groovy:groovy-all:4.0.24'
+    implementation "org.apache.groovy:groovy-all:$groovyVersion"
 }
 
 apply plugin: 'org.grails.grails-publish'

--- a/src/e2eTest/resources/publish-projects/legacy-apply/multi-project-parent-child-setup-per-project-parent-published/build.gradle
+++ b/src/e2eTest/resources/publish-projects/legacy-apply/multi-project-parent-child-setup-per-project-parent-published/build.gradle
@@ -20,7 +20,7 @@ allprojects {
     apply plugin: 'groovy'
 
     dependencies {
-        implementation 'org.apache.groovy:groovy-all:4.0.24'
+        implementation "org.apache.groovy:groovy-all:$groovyVersion"
     }
 }
 

--- a/src/e2eTest/resources/publish-projects/legacy-apply/multi-project-parent-child-setup-per-project-parent-published/subproject2/build.gradle
+++ b/src/e2eTest/resources/publish-projects/legacy-apply/multi-project-parent-child-setup-per-project-parent-published/subproject2/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    implementation 'org.apache.groovy:groovy-all:4.0.24'
+    implementation "org.apache.groovy:groovy-all:$groovyVersion"
 }

--- a/src/e2eTest/resources/publish-projects/legacy-apply/multi-project-with-subproject-gradle/subproject1/build.gradle
+++ b/src/e2eTest/resources/publish-projects/legacy-apply/multi-project-with-subproject-gradle/subproject1/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    implementation 'org.apache.groovy:groovy-all:4.0.24'
+    implementation "org.apache.groovy:groovy-all:$groovyVersion"
 }
 
 logger.lifecycle("Not applying grails-publish plugin to project `${project.name}`")

--- a/src/e2eTest/resources/publish-projects/legacy-apply/multi-project-with-subproject-gradle/subproject2/build.gradle
+++ b/src/e2eTest/resources/publish-projects/legacy-apply/multi-project-with-subproject-gradle/subproject2/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    implementation 'org.apache.groovy:groovy-all:4.0.24'
+    implementation "org.apache.groovy:groovy-all:$groovyVersion"
 }
 
 apply plugin: 'org.grails.grails-publish'

--- a/src/e2eTest/resources/publish-projects/other-artifacts/explicit-jar-creation-without-gradle-assistance/build.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/explicit-jar-creation-without-gradle-assistance/build.gradle
@@ -1,0 +1,53 @@
+buildscript {
+    repositories {
+        maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        maven { url = 'https://repo.grails.org/grails/core' }
+    }
+    dependencies {
+        classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
+    }
+}
+
+allprojects {
+    repositories {
+        maven { url = 'https://repo.grails.org/grails/core' }
+    }
+}
+
+version "${projectVersion}"
+group "org.grails.example"
+
+apply plugin: 'java-library'
+apply plugin: 'groovy'
+
+dependencies {
+    implementation 'org.apache.groovy:groovy-all:4.0.24'
+}
+
+apply plugin: 'org.grails.grails-publish'
+grailsPublish {
+    githubSlug = 'grails/grails-gradle-plugin'
+    license {
+        name = 'Apache-2.0'
+    }
+    title = 'Grails Gradle Plugin - Example Project'
+    desc = 'A testing project for the grails gradle plugin'
+    developers = [
+            jdaugherty: 'James Daugherty',
+    ]
+}
+
+// Add sources and javadoc jar tasks
+if (!tasks.findByName('sourcesJar')) {
+    tasks.register('sourcesJar', Jar) {
+        archiveClassifier = 'sources'
+        from sourceSets.main.allSource
+    }
+}
+if (!tasks.findByName('javadocJar')) {
+    tasks.register('javadocJar', Jar) {
+        dependsOn 'javadoc'
+        archiveClassifier = 'javadoc'
+        from javadoc.destinationDir
+    }
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/explicit-jar-creation-without-gradle-assistance/build.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/explicit-jar-creation-without-gradle-assistance/build.gradle
@@ -21,7 +21,7 @@ apply plugin: 'java-library'
 apply plugin: 'groovy'
 
 dependencies {
-    implementation 'org.apache.groovy:groovy-all:4.0.24'
+    implementation "org.apache.groovy:groovy-all:$groovyVersion"
 }
 
 apply plugin: 'org.grails.grails-publish'

--- a/src/e2eTest/resources/publish-projects/other-artifacts/explicit-jar-creation-without-gradle-assistance/gradle.properties
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/explicit-jar-creation-without-gradle-assistance/gradle.properties
@@ -1,0 +1,1 @@
+projectVersion=0.0.1-SNAPSHOT

--- a/src/e2eTest/resources/publish-projects/other-artifacts/explicit-jar-creation-without-gradle-assistance/settings.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/explicit-jar-creation-without-gradle-assistance/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'explicit-jar-creation-without-gradle-assistance'

--- a/src/e2eTest/resources/publish-projects/other-artifacts/explicit-jar-creation-without-gradle-assistance/src/main/groovy/org/grails/example/MyProject.groovy
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/explicit-jar-creation-without-gradle-assistance/src/main/groovy/org/grails/example/MyProject.groovy
@@ -1,0 +1,7 @@
+package org.grails.example
+
+class MyProject {
+    def sayHello() {
+        println "Hello from SubProject2"
+    }
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/explicit-jar-creation-without-gradle-assistance/src/main/java/TestJava.java
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/explicit-jar-creation-without-gradle-assistance/src/main/java/TestJava.java
@@ -1,0 +1,11 @@
+/**
+ * Some example javadoc
+ */
+public class TestJava {
+    /**
+     * An example method
+     */
+    public void sayHelloFromJava() {
+        System.out.println("Hello");
+    }
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/groovy-doc-disabled/build.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/groovy-doc-disabled/build.gradle
@@ -21,7 +21,7 @@ apply plugin: 'java-library'
 apply plugin: 'groovy'
 
 dependencies {
-    implementation 'org.apache.groovy:groovy-all:4.0.24'
+    implementation "org.apache.groovy:groovy-all:$groovyVersion"
 }
 
 groovydoc.enabled = false

--- a/src/e2eTest/resources/publish-projects/other-artifacts/groovy-doc-disabled/build.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/groovy-doc-disabled/build.gradle
@@ -1,0 +1,40 @@
+buildscript {
+    repositories {
+        maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        maven { url = 'https://repo.grails.org/grails/core' }
+    }
+    dependencies {
+        classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
+    }
+}
+
+allprojects {
+    repositories {
+        maven { url = 'https://repo.grails.org/grails/core' }
+    }
+}
+
+version "${projectVersion}"
+group "org.grails.example"
+
+apply plugin: 'java-library'
+apply plugin: 'groovy'
+
+dependencies {
+    implementation 'org.apache.groovy:groovy-all:4.0.24'
+}
+
+groovydoc.enabled = false
+
+apply plugin: 'org.grails.grails-publish'
+grailsPublish {
+    githubSlug = 'grails/grails-gradle-plugin'
+    license {
+        name = 'Apache-2.0'
+    }
+    title = 'Grails Gradle Plugin - Example Project'
+    desc = 'A testing project for the grails gradle plugin'
+    developers = [
+            jdaugherty: 'James Daugherty',
+    ]
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/groovy-doc-disabled/gradle.properties
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/groovy-doc-disabled/gradle.properties
@@ -1,0 +1,1 @@
+projectVersion=0.0.1-SNAPSHOT

--- a/src/e2eTest/resources/publish-projects/other-artifacts/groovy-doc-disabled/settings.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/groovy-doc-disabled/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'groovy-doc-disabled'

--- a/src/e2eTest/resources/publish-projects/other-artifacts/groovy-doc-disabled/src/main/groovy/org/grails/example/MyProject.groovy
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/groovy-doc-disabled/src/main/groovy/org/grails/example/MyProject.groovy
@@ -1,0 +1,7 @@
+package org.grails.example
+
+class MyProject {
+    def sayHello() {
+        println "Hello from SubProject2"
+    }
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/groovy-doc-disabled/src/main/java/TestJava.java
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/groovy-doc-disabled/src/main/java/TestJava.java
@@ -1,0 +1,11 @@
+/**
+ * Some example javadoc
+ */
+public class TestJava {
+    /**
+     * An example method
+     */
+    public void sayHelloFromJava() {
+        System.out.println("Hello");
+    }
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/groovy-only-project/build.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/groovy-only-project/build.gradle
@@ -1,0 +1,38 @@
+buildscript {
+    repositories {
+        maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        maven { url = 'https://repo.grails.org/grails/core' }
+    }
+    dependencies {
+        classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
+    }
+}
+
+allprojects {
+    repositories {
+        maven { url = 'https://repo.grails.org/grails/core' }
+    }
+}
+
+version "${projectVersion}"
+group "org.grails.example"
+
+apply plugin: 'java-library'
+apply plugin: 'groovy'
+
+dependencies {
+    implementation 'org.apache.groovy:groovy-all:4.0.24'
+}
+
+apply plugin: 'org.grails.grails-publish'
+grailsPublish {
+    githubSlug = 'grails/grails-gradle-plugin'
+    license {
+        name = 'Apache-2.0'
+    }
+    title = 'Grails Gradle Plugin - Example Project'
+    desc = 'A testing project for the grails gradle plugin'
+    developers = [
+            jdaugherty: 'James Daugherty',
+    ]
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/groovy-only-project/build.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/groovy-only-project/build.gradle
@@ -21,7 +21,7 @@ apply plugin: 'java-library'
 apply plugin: 'groovy'
 
 dependencies {
-    implementation 'org.apache.groovy:groovy-all:4.0.24'
+    implementation "org.apache.groovy:groovy-all:$groovyVersion"
 }
 
 apply plugin: 'org.grails.grails-publish'

--- a/src/e2eTest/resources/publish-projects/other-artifacts/groovy-only-project/gradle.properties
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/groovy-only-project/gradle.properties
@@ -1,0 +1,1 @@
+projectVersion=0.0.1-SNAPSHOT

--- a/src/e2eTest/resources/publish-projects/other-artifacts/groovy-only-project/settings.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/groovy-only-project/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'groovy-only-project'

--- a/src/e2eTest/resources/publish-projects/other-artifacts/groovy-only-project/src/main/groovy/org/grails/example/MyProject.groovy
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/groovy-only-project/src/main/groovy/org/grails/example/MyProject.groovy
@@ -1,0 +1,7 @@
+package org.grails.example
+
+class MyProject {
+    def sayHello() {
+        println "Hello from SubProject2"
+    }
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/java-already-configured/build.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/java-already-configured/build.gradle
@@ -21,7 +21,7 @@ apply plugin: 'java-library'
 apply plugin: 'groovy'
 
 dependencies {
-    implementation 'org.apache.groovy:groovy-all:4.0.24'
+    implementation "org.apache.groovy:groovy-all:$groovyVersion"
 }
 
 java {

--- a/src/e2eTest/resources/publish-projects/other-artifacts/java-already-configured/build.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/java-already-configured/build.gradle
@@ -1,0 +1,43 @@
+buildscript {
+    repositories {
+        maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        maven { url = 'https://repo.grails.org/grails/core' }
+    }
+    dependencies {
+        classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
+    }
+}
+
+allprojects {
+    repositories {
+        maven { url = 'https://repo.grails.org/grails/core' }
+    }
+}
+
+version "${projectVersion}"
+group "org.grails.example"
+
+apply plugin: 'java-library'
+apply plugin: 'groovy'
+
+dependencies {
+    implementation 'org.apache.groovy:groovy-all:4.0.24'
+}
+
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
+apply plugin: 'org.grails.grails-publish'
+grailsPublish {
+    githubSlug = 'grails/grails-gradle-plugin'
+    license {
+        name = 'Apache-2.0'
+    }
+    title = 'Grails Gradle Plugin - Example Project'
+    desc = 'A testing project for the grails gradle plugin'
+    developers = [
+            jdaugherty: 'James Daugherty',
+    ]
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/java-already-configured/gradle.properties
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/java-already-configured/gradle.properties
@@ -1,0 +1,1 @@
+projectVersion=0.0.1-SNAPSHOT

--- a/src/e2eTest/resources/publish-projects/other-artifacts/java-already-configured/settings.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/java-already-configured/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'java-already-configured'

--- a/src/e2eTest/resources/publish-projects/other-artifacts/java-already-configured/src/main/groovy/org/grails/example/MyProject.groovy
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/java-already-configured/src/main/groovy/org/grails/example/MyProject.groovy
@@ -1,0 +1,7 @@
+package org.grails.example
+
+class MyProject {
+    def sayHello() {
+        println "Hello from SubProject2"
+    }
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/java-already-configured/src/main/java/TestJava.java
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/java-already-configured/src/main/java/TestJava.java
@@ -1,0 +1,11 @@
+/**
+ * Some example javadoc
+ */
+public class TestJava {
+    /**
+     * An example method
+     */
+    public void sayHelloFromJava() {
+        System.out.println("Hello");
+    }
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/java-only-project/build.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/java-only-project/build.gradle
@@ -1,0 +1,33 @@
+buildscript {
+    repositories {
+        maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        maven { url = 'https://repo.grails.org/grails/core' }
+    }
+    dependencies {
+        classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
+    }
+}
+
+allprojects {
+    repositories {
+        maven { url = 'https://repo.grails.org/grails/core' }
+    }
+}
+
+version "${projectVersion}"
+group "org.grails.example"
+
+apply plugin: 'java-library'
+
+apply plugin: 'org.grails.grails-publish'
+grailsPublish {
+    githubSlug = 'grails/grails-gradle-plugin'
+    license {
+        name = 'Apache-2.0'
+    }
+    title = 'Grails Gradle Plugin - Example Project'
+    desc = 'A testing project for the grails gradle plugin'
+    developers = [
+            jdaugherty: 'James Daugherty',
+    ]
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/java-only-project/gradle.properties
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/java-only-project/gradle.properties
@@ -1,0 +1,1 @@
+projectVersion=0.0.1-SNAPSHOT

--- a/src/e2eTest/resources/publish-projects/other-artifacts/java-only-project/settings.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/java-only-project/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'java-only-project'

--- a/src/e2eTest/resources/publish-projects/other-artifacts/java-only-project/src/main/java/TestJava.java
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/java-only-project/src/main/java/TestJava.java
@@ -1,0 +1,11 @@
+/**
+ * Some example javadoc
+ */
+public class TestJava {
+    /**
+     * An example method
+     */
+    public void sayHelloFromJava() {
+        System.out.println("Hello");
+    }
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-child/build.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-child/build.gradle
@@ -1,0 +1,39 @@
+buildscript {
+    repositories {
+        maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        maven { url = 'https://repo.grails.org/grails/core' }
+    }
+    dependencies {
+        classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
+    }
+}
+
+version "${projectVersion}"
+group "org.grails.example"
+
+subprojects { project ->
+    version "${projectVersion}"
+    group "org.grails.example"
+
+    repositories {
+        maven { url = 'https://repo.grails.org/grails/core' }
+    }
+
+    if(project.name == "subproject1") {
+        apply plugin: 'org.grails.grails-publish'
+        grailsPublish {
+            githubSlug = 'grails/grails-gradle-plugin'
+            license {
+                name = 'Apache-2.0'
+            }
+            title = 'Grails Gradle Plugin - Example Project'
+            desc = 'A testing project for the grails gradle plugin'
+            developers = [
+                    jdaugherty: 'James Daugherty',
+            ]
+        }
+    }
+    else {
+        logger.lifecycle("Not applying grails-publish plugin to project `${project.name}`")
+    }
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-child/gradle.properties
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-child/gradle.properties
@@ -1,0 +1,1 @@
+projectVersion=0.0.1-SNAPSHOT

--- a/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-child/settings.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-child/settings.gradle
@@ -1,0 +1,4 @@
+rootProject.name = 'multi-project-plugins-applied-child'
+
+include 'subproject1'
+include 'subproject2'

--- a/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-child/subproject1/build.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-child/subproject1/build.gradle
@@ -1,0 +1,5 @@
+apply plugin: 'java-library'
+apply plugin: 'groovy'
+dependencies {
+    implementation 'org.apache.groovy:groovy-all:4.0.24'
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-child/subproject1/build.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-child/subproject1/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'java-library'
 apply plugin: 'groovy'
 dependencies {
-    implementation 'org.apache.groovy:groovy-all:4.0.24'
+    implementation "org.apache.groovy:groovy-all:$groovyVersion"
 }

--- a/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-child/subproject1/src/main/groovy/org/grails/example/SubProject1.groovy
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-child/subproject1/src/main/groovy/org/grails/example/SubProject1.groovy
@@ -1,0 +1,7 @@
+package org.grails.example
+
+class SubProject1 {
+    def sayHello() {
+        println "Hello from SubProject1"
+    }
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-child/subproject1/src/main/java/TestJava.java
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-child/subproject1/src/main/java/TestJava.java
@@ -1,0 +1,11 @@
+/**
+ * Some example javadoc
+ */
+public class TestJava {
+    /**
+     * An example method
+     */
+    public void sayHelloFromJava() {
+        System.out.println("Hello");
+    }
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-child/subproject2/build.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-child/subproject2/build.gradle
@@ -1,0 +1,5 @@
+apply plugin: 'java-library'
+apply plugin: 'groovy'
+dependencies {
+    implementation 'org.apache.groovy:groovy-all:4.0.24'
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-child/subproject2/build.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-child/subproject2/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'java-library'
 apply plugin: 'groovy'
 dependencies {
-    implementation 'org.apache.groovy:groovy-all:4.0.24'
+    implementation "org.apache.groovy:groovy-all:$groovyVersion"
 }

--- a/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-child/subproject2/src/main/groovy/org/grails/example/SubProject2.groovy
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-child/subproject2/src/main/groovy/org/grails/example/SubProject2.groovy
@@ -1,0 +1,7 @@
+package org.grails.example
+
+class SubProject2 {
+    def sayHello() {
+        println "Hello from SubProject2"
+    }
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-parent/build.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-parent/build.gradle
@@ -23,7 +23,7 @@ subprojects { project ->
     }
 
     dependencies {
-        implementation 'org.apache.groovy:groovy-all:4.0.24'
+        implementation "org.apache.groovy:groovy-all:$groovyVersion"
     }
 
     if(project.name == "subproject1") {

--- a/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-parent/build.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-parent/build.gradle
@@ -1,0 +1,46 @@
+buildscript {
+    repositories {
+        maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        maven { url = 'https://repo.grails.org/grails/core' }
+    }
+    dependencies {
+        classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
+    }
+}
+
+version "${projectVersion}"
+group "org.grails.example"
+
+subprojects { project ->
+    version "${projectVersion}"
+    group "org.grails.example"
+
+    apply plugin: 'java-library'
+    apply plugin: 'groovy'
+
+    repositories {
+        maven { url = 'https://repo.grails.org/grails/core' }
+    }
+
+    dependencies {
+        implementation 'org.apache.groovy:groovy-all:4.0.24'
+    }
+
+    if(project.name == "subproject1") {
+        apply plugin: 'org.grails.grails-publish'
+        grailsPublish {
+            githubSlug = 'grails/grails-gradle-plugin'
+            license {
+                name = 'Apache-2.0'
+            }
+            title = 'Grails Gradle Plugin - Example Project'
+            desc = 'A testing project for the grails gradle plugin'
+            developers = [
+                    jdaugherty: 'James Daugherty',
+            ]
+        }
+    }
+    else {
+        logger.lifecycle("Not applying grails-publish plugin to project `${project.name}`")
+    }
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-parent/gradle.properties
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-parent/gradle.properties
@@ -1,0 +1,1 @@
+projectVersion=0.0.1-SNAPSHOT

--- a/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-parent/settings.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-parent/settings.gradle
@@ -1,0 +1,4 @@
+rootProject.name = 'multi-project-plugins-applied-parent'
+
+include 'subproject1'
+include 'subproject2'

--- a/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-parent/subproject1/src/main/groovy/org/grails/example/SubProject1.groovy
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-parent/subproject1/src/main/groovy/org/grails/example/SubProject1.groovy
@@ -1,0 +1,7 @@
+package org.grails.example
+
+class SubProject1 {
+    def sayHello() {
+        println "Hello from SubProject1"
+    }
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-parent/subproject1/src/main/java/TestJava.java
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-parent/subproject1/src/main/java/TestJava.java
@@ -1,0 +1,11 @@
+/**
+ * Some example javadoc
+ */
+public class TestJava {
+    /**
+     * An example method
+     */
+    public void sayHelloFromJava() {
+        System.out.println("Hello");
+    }
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-parent/subproject2/src/main/groovy/org/grails/example/SubProject2.groovy
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-parent/subproject2/src/main/groovy/org/grails/example/SubProject2.groovy
@@ -1,0 +1,7 @@
+package org.grails.example
+
+class SubProject2 {
+    def sayHello() {
+        println "Hello from SubProject2"
+    }
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/multiple-source-sets/build.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/multiple-source-sets/build.gradle
@@ -1,0 +1,60 @@
+buildscript {
+    repositories {
+        maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        maven { url = 'https://repo.grails.org/grails/core' }
+    }
+    dependencies {
+        classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
+    }
+}
+
+allprojects {
+    repositories {
+        maven { url = 'https://repo.grails.org/grails/core' }
+    }
+}
+
+version "${projectVersion}"
+group "org.grails.example"
+
+apply plugin: 'java-library'
+apply plugin: 'groovy'
+
+sourceSets {
+    other {
+        groovy {
+            compileClasspath += configurations.compileClasspath
+        }
+    }
+    main {
+        compileClasspath += sourceSets.other.output
+    }
+    test {
+        compileClasspath += sourceSets.other.output
+    }
+}
+
+def copyOtherClasses = project.tasks.register('copyOtherClasses', Copy) {
+    it.from sourceSets.other.output
+    it.into project.layout.buildDirectory.dir("classes/groovy/main")
+}
+
+def taskContainer = project.tasks
+taskContainer.named('classes').configure { it.dependsOn(copyOtherClasses) }
+
+taskContainer.withType(JavaExec).configureEach {
+    it.classpath += sourceSets.other.output
+}
+
+apply plugin: 'org.grails.grails-publish'
+grailsPublish {
+    githubSlug = 'grails/grails-gradle-plugin'
+    license {
+        name = 'Apache-2.0'
+    }
+    title = 'Grails Gradle Plugin - Example Project'
+    desc = 'A testing project for the grails gradle plugin'
+    developers = [
+            jdaugherty: 'James Daugherty',
+    ]
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/multiple-source-sets/gradle.properties
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/multiple-source-sets/gradle.properties
@@ -1,0 +1,1 @@
+projectVersion=0.0.1-SNAPSHOT

--- a/src/e2eTest/resources/publish-projects/other-artifacts/multiple-source-sets/settings.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/multiple-source-sets/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'multiple-source-sets'

--- a/src/e2eTest/resources/publish-projects/other-artifacts/multiple-source-sets/src/main/groovy/org/grails/example/MyProject.groovy
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/multiple-source-sets/src/main/groovy/org/grails/example/MyProject.groovy
@@ -1,0 +1,7 @@
+package org.grails.example
+
+class MyProject {
+    def sayHello() {
+        println "Hello from SubProject2"
+    }
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/multiple-source-sets/src/main/java/TestJava.java
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/multiple-source-sets/src/main/java/TestJava.java
@@ -1,0 +1,11 @@
+/**
+ * Some example javadoc
+ */
+public class TestJava {
+    /**
+     * An example method
+     */
+    public void sayHelloFromJava() {
+        System.out.println("Hello");
+    }
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/multiple-source-sets/src/other/groovy/org/grails/example/Library.groovy
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/multiple-source-sets/src/other/groovy/org/grails/example/Library.groovy
@@ -1,0 +1,7 @@
+package org.grails.example
+
+class Library {
+    def sayHello() {
+        println "Hello from Library"
+    }
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/non-groovy-java-sources-included/build.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/non-groovy-java-sources-included/build.gradle
@@ -1,0 +1,38 @@
+buildscript {
+    repositories {
+        maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        maven { url = 'https://repo.grails.org/grails/core' }
+    }
+    dependencies {
+        classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
+    }
+}
+
+allprojects {
+    repositories {
+        maven { url = 'https://repo.grails.org/grails/core' }
+    }
+}
+
+version "${projectVersion}"
+group "org.grails.example"
+
+apply plugin: 'java-library'
+apply plugin: 'groovy'
+
+dependencies {
+    implementation 'org.apache.groovy:groovy-all:4.0.24'
+}
+
+apply plugin: 'org.grails.grails-publish'
+grailsPublish {
+    githubSlug = 'grails/grails-gradle-plugin'
+    license {
+        name = 'Apache-2.0'
+    }
+    title = 'Grails Gradle Plugin - Example Project'
+    desc = 'A testing project for the grails gradle plugin'
+    developers = [
+            jdaugherty: 'James Daugherty',
+    ]
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/non-groovy-java-sources-included/build.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/non-groovy-java-sources-included/build.gradle
@@ -21,7 +21,7 @@ apply plugin: 'java-library'
 apply plugin: 'groovy'
 
 dependencies {
-    implementation 'org.apache.groovy:groovy-all:4.0.24'
+    implementation "org.apache.groovy:groovy-all:$groovyVersion"
 }
 
 apply plugin: 'org.grails.grails-publish'

--- a/src/e2eTest/resources/publish-projects/other-artifacts/non-groovy-java-sources-included/gradle.properties
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/non-groovy-java-sources-included/gradle.properties
@@ -1,0 +1,1 @@
+projectVersion=0.0.1-SNAPSHOT

--- a/src/e2eTest/resources/publish-projects/other-artifacts/non-groovy-java-sources-included/settings.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/non-groovy-java-sources-included/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'non-groovy-java-sources-included'

--- a/src/e2eTest/resources/publish-projects/other-artifacts/non-groovy-java-sources-included/src/main/groovy/org/grails/example/MyProject.groovy
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/non-groovy-java-sources-included/src/main/groovy/org/grails/example/MyProject.groovy
@@ -1,0 +1,7 @@
+package org.grails.example
+
+class MyProject {
+    def sayHello() {
+        println "Hello from SubProject2"
+    }
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/non-groovy-java-sources-included/src/main/java/TestJava.java
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/non-groovy-java-sources-included/src/main/java/TestJava.java
@@ -1,0 +1,11 @@
+/**
+ * Some example javadoc
+ */
+public class TestJava {
+    /**
+     * An example method
+     */
+    public void sayHelloFromJava() {
+        System.out.println("Hello");
+    }
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/non-groovy-java-sources-included/src/main/resources/Testing.txt
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/non-groovy-java-sources-included/src/main/resources/Testing.txt
@@ -1,0 +1,1 @@
+This is a resource

--- a/src/e2eTest/resources/publish-projects/other-artifacts/simple-project/build.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/simple-project/build.gradle
@@ -1,0 +1,38 @@
+buildscript {
+    repositories {
+        maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        maven { url = 'https://repo.grails.org/grails/core' }
+    }
+    dependencies {
+        classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
+    }
+}
+
+allprojects {
+    repositories {
+        maven { url = 'https://repo.grails.org/grails/core' }
+    }
+}
+
+version "${projectVersion}"
+group "org.grails.example"
+
+apply plugin: 'java-library'
+apply plugin: 'groovy'
+
+dependencies {
+    implementation 'org.apache.groovy:groovy-all:4.0.24'
+}
+
+apply plugin: 'org.grails.grails-publish'
+grailsPublish {
+    githubSlug = 'grails/grails-gradle-plugin'
+    license {
+        name = 'Apache-2.0'
+    }
+    title = 'Grails Gradle Plugin - Example Project'
+    desc = 'A testing project for the grails gradle plugin'
+    developers = [
+            jdaugherty: 'James Daugherty',
+    ]
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/simple-project/build.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/simple-project/build.gradle
@@ -21,7 +21,7 @@ apply plugin: 'java-library'
 apply plugin: 'groovy'
 
 dependencies {
-    implementation 'org.apache.groovy:groovy-all:4.0.24'
+    implementation "org.apache.groovy:groovy-all:$groovyVersion"
 }
 
 apply plugin: 'org.grails.grails-publish'

--- a/src/e2eTest/resources/publish-projects/other-artifacts/simple-project/gradle.properties
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/simple-project/gradle.properties
@@ -1,0 +1,1 @@
+projectVersion=0.0.1-SNAPSHOT

--- a/src/e2eTest/resources/publish-projects/other-artifacts/simple-project/settings.gradle
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/simple-project/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'simple-project'

--- a/src/e2eTest/resources/publish-projects/other-artifacts/simple-project/src/main/groovy/org/grails/example/MyProject.groovy
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/simple-project/src/main/groovy/org/grails/example/MyProject.groovy
@@ -1,0 +1,7 @@
+package org.grails.example
+
+class MyProject {
+    def sayHello() {
+        println "Hello from SubProject2"
+    }
+}

--- a/src/e2eTest/resources/publish-projects/other-artifacts/simple-project/src/main/java/TestJava.java
+++ b/src/e2eTest/resources/publish-projects/other-artifacts/simple-project/src/main/java/TestJava.java
@@ -1,0 +1,11 @@
+/**
+ * Some example javadoc
+ */
+public class TestJava {
+    /**
+     * An example method
+     */
+    public void sayHelloFromJava() {
+        System.out.println("Hello");
+    }
+}

--- a/src/e2eTest/resources/publish-projects/plugins-block/child-project-with-unrelated-parent/build.gradle
+++ b/src/e2eTest/resources/publish-projects/plugins-block/child-project-with-unrelated-parent/build.gradle
@@ -22,7 +22,7 @@ version "${projectVersion}"
 group "org.grails.example"
 
 dependencies {
-    implementation 'org.apache.groovy:groovy-all:4.0.24'
+    implementation "org.apache.groovy:groovy-all:$groovyVersion"
 }
 
 grailsPublish {

--- a/src/e2eTest/resources/publish-projects/plugins-block/child-project-with-unrelated-parent/otherProject/build.gradle
+++ b/src/e2eTest/resources/publish-projects/plugins-block/child-project-with-unrelated-parent/otherProject/build.gradle
@@ -21,6 +21,6 @@ version "${projectVersion}"
 group "org.grails.example"
 
 dependencies {
-    implementation 'org.apache.groovy:groovy-all:4.0.24'
+    implementation "org.apache.groovy:groovy-all:$groovyVersion"
     implementation 'org.grails.example:subproject1'
 }

--- a/src/e2eTest/resources/publish-projects/plugins-block/multi-project-parent-child-setup-per-project-child-published/build.gradle
+++ b/src/e2eTest/resources/publish-projects/plugins-block/multi-project-parent-child-setup-per-project-child-published/build.gradle
@@ -23,7 +23,7 @@ version "${projectVersion}"
 group "org.grails.example"
 
 dependencies {
-    implementation 'org.apache.groovy:groovy-all:4.0.24'
+    implementation "org.apache.groovy:groovy-all:$groovyVersion"
 }
 
 subprojects { project ->

--- a/src/e2eTest/resources/publish-projects/plugins-block/multi-project-parent-child-setup-per-project-child-published/subproject2/build.gradle
+++ b/src/e2eTest/resources/publish-projects/plugins-block/multi-project-parent-child-setup-per-project-child-published/subproject2/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-    implementation 'org.apache.groovy:groovy-all:4.0.24'
+    implementation "org.apache.groovy:groovy-all:$groovyVersion"
 }
 
 grailsPublish {

--- a/src/e2eTest/resources/publish-projects/plugins-block/multi-project-parent-child-setup-per-project-parent-published/build.gradle
+++ b/src/e2eTest/resources/publish-projects/plugins-block/multi-project-parent-child-setup-per-project-parent-published/build.gradle
@@ -18,7 +18,7 @@ version "${projectVersion}"
 group "org.grails.example"
 
 dependencies {
-    implementation 'org.apache.groovy:groovy-all:4.0.24'
+    implementation "org.apache.groovy:groovy-all:$groovyVersion"
 }
 
 allprojects {

--- a/src/e2eTest/resources/publish-projects/plugins-block/multi-project-parent-child-setup-per-project-parent-published/subproject2/build.gradle
+++ b/src/e2eTest/resources/publish-projects/plugins-block/multi-project-parent-child-setup-per-project-parent-published/subproject2/build.gradle
@@ -4,5 +4,5 @@ plugins {
 }
 
 dependencies {
-    implementation 'org.apache.groovy:groovy-all:4.0.24'
+    implementation "org.apache.groovy:groovy-all:$groovyVersion"
 }

--- a/src/e2eTest/resources/publish-projects/plugins-block/multi-project-with-subproject-gradle/subproject1/build.gradle
+++ b/src/e2eTest/resources/publish-projects/plugins-block/multi-project-with-subproject-gradle/subproject1/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation 'org.apache.groovy:groovy-all:4.0.24'
+    implementation "org.apache.groovy:groovy-all:$groovyVersion"
 }
 
 logger.lifecycle("Not applying grails-publish plugin to project `${project.name}`")

--- a/src/e2eTest/resources/publish-projects/plugins-block/multi-project-with-subproject-gradle/subproject2/build.gradle
+++ b/src/e2eTest/resources/publish-projects/plugins-block/multi-project-with-subproject-gradle/subproject2/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-    implementation 'org.apache.groovy:groovy-all:4.0.24'
+    implementation "org.apache.groovy:groovy-all:$groovyVersion"
 }
 
 grailsPublish {


### PR DESCRIPTION
@matrei we need to start switching to the publish plugin everywhere after we merge this.  It will ensure we're correctly publishing source & javadoc for all projects if we do.