### PR TITLE
Change and standardize profile task names so it can be used w/ Gradle Java Plugin

### DIFF
--- a/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfileGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfileGradlePlugin.groovy
@@ -90,12 +90,14 @@ class GrailsProfileGradlePlugin implements Plugin<Project> {
         }
 
         def processProfileResourcesTask = project.tasks.register("processProfileResources", Copy, { Copy c ->
+            c.group = "build"
             c.with(spec1, spec2, spec3, spec4)
             c.into(new File(resourcesDir, "/META-INF/grails-profile"))
         })
 
         def classsesDir = new File(project.layout.buildDirectory.getAsFile().get(), "classes/profile")
         def compileProfileTask = project.tasks.register("compileProfile", ProfileCompilerTask, { ProfileCompilerTask task ->
+            task.group = "build"
             task.profileDestinationDir = classsesDir
             task.source = commandsDir
             task.config = profileYml

--- a/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfileGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfileGradlePlugin.groovy
@@ -89,13 +89,13 @@ class GrailsProfileGradlePlugin implements Plugin<Project> {
             spec.into("skeleton")
         }
 
-        def processResources = project.tasks.create("processResources", Copy, { Copy c ->
+        def processProfileResourcesTask = project.tasks.register("processProfileResources", Copy, { Copy c ->
             c.with(spec1, spec2, spec3, spec4)
             c.into(new File(resourcesDir, "/META-INF/grails-profile"))
         })
 
         def classsesDir = new File(project.layout.buildDirectory.getAsFile().get(), "classes/profile")
-        def compileTask = project.tasks.create("compileProfile", ProfileCompilerTask, { ProfileCompilerTask task ->
+        def compileProfileTask = project.tasks.register("compileProfile", ProfileCompilerTask, { ProfileCompilerTask task ->
             task.profileDestinationDir = classsesDir
             task.source = commandsDir
             task.config = profileYml
@@ -105,8 +105,8 @@ class GrailsProfileGradlePlugin implements Plugin<Project> {
             task.classpath = project.configurations.getByName(RUNTIME_CONFIGURATION) + project.files(IOUtils.findJarFile(GroovyScriptCommand))
         })
 
-        def jarTask = project.tasks.create("jar", Jar, { Jar jar ->
-            jar.dependsOn(processResources, compileTask)
+        def jarProfileTask = project.tasks.register("jarProfile", Jar, { Jar jar ->
+            jar.dependsOn(processProfileResourcesTask, compileProfileTask)
             jar.from(resourcesDir)
             jar.from(classsesDir)
             jar.destinationDirectory.set(new File(project.layout.buildDirectory.getAsFile().get(), "libs"))
@@ -117,7 +117,7 @@ class GrailsProfileGradlePlugin implements Plugin<Project> {
 //            project.artifacts.add(CONFIGURATION_NAME, jarArtifact)
         })
 
-        project.tasks.create("sourcesJar", Jar, { Jar jar ->
+        project.tasks.register("sourcesProfileJar", Jar, { Jar jar ->
             jar.from(commandsDir)
             if(profileYml.exists()) {
                 jar.from(profileYml)
@@ -134,7 +134,6 @@ class GrailsProfileGradlePlugin implements Plugin<Project> {
             jar.setGroup(BUILD_GROUP)
 
         })
-        project.tasks.findByName("assemble").dependsOn jarTask
-
+        project.tasks.findByName("assemble").dependsOn jarProfileTask
     }
 }

--- a/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfilePublishGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfilePublishGradlePlugin.groovy
@@ -45,7 +45,7 @@ class GrailsProfilePublishGradlePlugin extends GrailsPublishGradlePlugin {
         super.apply(project)
         final File tempReadmeForJavadoc = Files.createTempFile('README', 'txt').toFile()
         tempReadmeForJavadoc << 'https://central.sonatype.org/publish/requirements/#supply-javadoc-and-sources'
-        project.tasks.create('javadocJar', Jar, { Jar jar ->
+        project.tasks.register('javadocProfileJar', Jar, { Jar jar ->
             jar.from(tempReadmeForJavadoc)
             jar.archiveClassifier.set('javadoc')
             jar.destinationDirectory.set(new File(project.layout.buildDirectory.getAsFile().get(), 'libs'))
@@ -68,7 +68,10 @@ class GrailsProfilePublishGradlePlugin extends GrailsPublishGradlePlugin {
 
     @Override
     protected void doAddArtefact(Project project, MavenPublication publication) {
-        publication.artifact(project.tasks.findByName('jar'))
+        publication.artifact(project.tasks.findByName('jarProfile'))
+        publication.artifact(project.tasks.findByName('sourcesProfileJar'))
+        publication.artifact(project.tasks.findByName('javadocProfileJar'))
+
         publication.pom(new Action<MavenPom>() {
             @Override
             void execute(MavenPom mavenPom) {


### PR DESCRIPTION
Allows Java Gradle plugin to be applied via Groovy Gradle plugin for https://github.com/grails/grails-profiles/pull/8

Prior to this change the Java plugin could not be applied to Profile projects.