### PR TITLE
Add dependsOn Jar tasks for Profile publishing tasks

### DIFF
--- a/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfilePublishGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfilePublishGradlePlugin.groovy
@@ -25,8 +25,6 @@ import org.gradle.api.artifacts.SelfResolvingDependency
 import org.gradle.api.publish.maven.MavenPom
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.tasks.GenerateMavenPom
-import org.gradle.api.publish.maven.tasks.PublishToMavenLocal
-import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
 import org.gradle.api.tasks.bundling.Jar
 import org.grails.gradle.plugin.publishing.GrailsPublishGradlePlugin
 

--- a/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfilePublishGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfilePublishGradlePlugin.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.artifacts.DependencySet
 import org.gradle.api.artifacts.SelfResolvingDependency
 import org.gradle.api.publish.maven.MavenPom
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.publish.maven.tasks.GenerateMavenPom
 import org.gradle.api.publish.maven.tasks.PublishToMavenLocal
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
 import org.gradle.api.tasks.bundling.Jar
@@ -56,12 +57,8 @@ class GrailsProfilePublishGradlePlugin extends GrailsPublishGradlePlugin {
         })
 
         project.afterEvaluate { evaluated ->
-            evaluated.tasks.withType(PublishToMavenLocal).each { publishToMavenLocalTask ->
-                publishToMavenLocalTask.dependsOn(project.tasks.withType(Jar))
-            }
-
-            evaluated.tasks.withType(PublishToMavenRepository).each {publishToMavenRepositoryTask ->
-                publishToMavenRepositoryTask.dependsOn(project.tasks.withType(Jar))
+            evaluated.tasks.withType(GenerateMavenPom).each { generateMavenPom ->
+                generateMavenPom.dependsOn(project.tasks.withType(Jar))
             }
         }
     }

--- a/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfilePublishGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfilePublishGradlePlugin.groovy
@@ -24,6 +24,8 @@ import org.gradle.api.artifacts.DependencySet
 import org.gradle.api.artifacts.SelfResolvingDependency
 import org.gradle.api.publish.maven.MavenPom
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.publish.maven.tasks.PublishToMavenLocal
+import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
 import org.gradle.api.tasks.bundling.Jar
 import org.grails.gradle.plugin.publishing.GrailsPublishGradlePlugin
 
@@ -52,6 +54,16 @@ class GrailsProfilePublishGradlePlugin extends GrailsPublishGradlePlugin {
             jar.setDescription('Assembles a jar archive containing the profile javadoc.')
             jar.setGroup(BUILD_GROUP)
         })
+
+        project.afterEvaluate { evaluated ->
+            evaluated.tasks.withType(PublishToMavenLocal).each { publishToMavenLocalTask ->
+                publishToMavenLocalTask.dependsOn(project.tasks.withType(Jar))
+            }
+
+            evaluated.tasks.withType(PublishToMavenRepository).each {publishToMavenRepositoryTask ->
+                publishToMavenRepositoryTask.dependsOn(project.tasks.withType(Jar))
+            }
+        }
     }
 
     @Override

--- a/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfilePublishGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfilePublishGradlePlugin.groovy
@@ -55,8 +55,8 @@ class GrailsProfilePublishGradlePlugin extends GrailsPublishGradlePlugin {
         })
 
         project.afterEvaluate { evaluated ->
-            evaluated.tasks.withType(GenerateMavenPom).each { generateMavenPom ->
-                generateMavenPom.dependsOn(project.tasks.withType(Jar))
+            evaluated.tasks.withType(GenerateMavenPom).each { generateMavenPomTask ->
+                generateMavenPomTask.dependsOn(project.tasks.withType(Jar))
             }
         }
     }


### PR DESCRIPTION
Resolves the following during Profile publishing:

```
> Task :base:jar FAILED


FAILURE: Build failed with an exception.
[Incubating] Problems report is available at: file:///home/runner/work/grails-profiles/grails-profiles/build/reports/problems/problems-report.html

* What went wrong:
A problem was found with the configuration of task ':base:jar' (type 'Jar').
  - Gradle detected a problem with the following location: '/home/runner/work/grails-profiles/grails-profiles/base/build/libs/base-10.0.2-SNAPSHOT.jar'.
    
    Reason: Task ':base:publishMavenPublicationToMavenRepository' uses this output of task ':base:jar' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':base:jar' as an input of ':base:publishMavenPublicationToMavenRepository'.
      2. Declare an explicit dependency on ':base:jar' from ':base:publishMavenPublicationToMavenRepository' using Task#dependsOn.
      3. Declare an explicit dependency on ':base:jar' from ':base:publishMavenPublicationToMavenRepository' using Task#mustRunAfter.
    
    For more information, please refer to https://docs.gradle.org/8.12/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.
```

