### PR TITLE
Make profileJar task dependent on java plugin jar task 

### DIFF
--- a/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfileGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfileGradlePlugin.groovy
@@ -108,7 +108,7 @@ class GrailsProfileGradlePlugin implements Plugin<Project> {
         })
 
         def profileJarTask = project.tasks.register("profileJar", Jar, { Jar jar ->
-            jar.dependsOn(processProfileResourcesTask, compileProfileTask)
+            jar.dependsOn(processProfileResourcesTask, compileProfileTask, project.tasks.findByName("jar"))
             jar.from(resourcesDir)
             jar.from(classsesDir)
             jar.destinationDirectory.set(new File(project.layout.buildDirectory.getAsFile().get(), "libs"))

--- a/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfileGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfileGradlePlugin.groovy
@@ -108,7 +108,13 @@ class GrailsProfileGradlePlugin implements Plugin<Project> {
         })
 
         def profileJarTask = project.tasks.register("profileJar", Jar, { Jar jar ->
-            jar.dependsOn(processProfileResourcesTask, compileProfileTask, project.tasks.findByName("jar"))
+            jar.dependsOn(processProfileResourcesTask, compileProfileTask)
+
+            def jarTask = project.tasks.findByName("jar")
+            if(jarTask){
+                jar.dependsOn(jarTask)
+            }
+
             jar.from(resourcesDir)
             jar.from(classsesDir)
             jar.destinationDirectory.set(new File(project.layout.buildDirectory.getAsFile().get(), "libs"))


### PR DESCRIPTION
to resolve issue with base profile missing the resources from build.

