### PR TITLE
Update profile publish to support self resolving 'project(":base")' dependencies

### DIFF
--- a/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfilePublishGradlePlugin.groovy
+++ b/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfilePublishGradlePlugin.groovy
@@ -90,13 +90,11 @@ class GrailsProfilePublishGradlePlugin extends GrailsPublishGradlePlugin {
                         DependencySet dependencySet = project.configurations[GrailsProfileGradlePlugin.RUNTIME_CONFIGURATION].allDependencies
 
                         for (Dependency dependency : dependencySet) {
-                            if (! (dependency instanceof SelfResolvingDependency)) {
-                                Node dependencyNode = dependenciesNode.appendNode('dependency')
-                                dependencyNode.appendNode('groupId', dependency.group)
-                                dependencyNode.appendNode('artifactId', dependency.name)
-                                dependencyNode.appendNode('version', dependency.version)
-                                dependencyNode.appendNode('scope', GrailsProfileGradlePlugin.RUNTIME_CONFIGURATION)
-                            }
+                            Node dependencyNode = dependenciesNode.appendNode('dependency')
+                            dependencyNode.appendNode('groupId', dependency.group)
+                            dependencyNode.appendNode('artifactId', dependency.name)
+                            dependencyNode.appendNode('version', dependency.version)
+                            dependencyNode.appendNode('scope', GrailsProfileGradlePlugin.RUNTIME_CONFIGURATION)
                         }
                     }
                 })


### PR DESCRIPTION
Update profile publish to support self resolving `project(":base")` dependencies in consolidated grails-profile project

This restored the dependencies in the generated POM file.

```
  <dependencies>
    <dependency>
      <groupId>org.grails.profiles</groupId>
      <artifactId>base</artifactId>
      <version>10.0.2-SNAPSHOT</version>
      <scope>profileRuntimeOnly</scope>
    </dependency>
  </dependencies>
```

